### PR TITLE
Comments, length-related updates

### DIFF
--- a/core/scss/components/_components.alerts.scss
+++ b/core/scss/components/_components.alerts.scss
@@ -5,7 +5,6 @@
 
 .dcf-c-alert {
   @include grid;
-//   grid-gap: 1em;
   grid-template-areas:
     "header footer"
     "msg footer";

--- a/core/scss/components/_components.articles.scss
+++ b/core/scss/components/_components.articles.scss
@@ -34,7 +34,7 @@
 .dcf-c-article blockquote {
 
   + p {
-    text-indent: #{ms(4)}em;
+    text-indent: #{ms(4)}em; // 1.77em
   }
 
 }
@@ -47,7 +47,7 @@
 
 .dcf-c-author-img img {
   @include block;
-  width: #{ms(8)}em;
+  width: #{ms(8)}em; // 3.16em
 }
 
 
@@ -81,7 +81,7 @@
 
     .dcf-c-article {
       @include grid;
-      grid-template-columns: #{ms(8)}em 1fr;
+      grid-template-columns: #{ms(8)}em 1fr; // 3.16em
       grid-template-areas:
         "share header"
         "share body"
@@ -100,7 +100,7 @@
       grid-area: share;
 
       .dcf-u-sticky {
-        top: #{ms(2)}em;
+        top: #{ms(2)}em; // 1.33em
       }
 
       div[role="heading"] {

--- a/core/scss/components/_components.badges.scss
+++ b/core/scss/components/_components.badges.scss
@@ -6,8 +6,8 @@
 // !Default (Roundrect) Badges
 .dcf-c-badge {
   @include inlineblock;
-  padding-top: #{ms(-10)}rem; // .238rem
-  padding-bottom: #{ms(-10)}rem; // .238rem
+  padding-top: #{ms(-10)}rem; // .24rem
+  padding-bottom: #{ms(-10)}rem; // .24rem
   @include sm4;
   @include lh3;
   color: #fff;

--- a/core/scss/components/_components.events.scss
+++ b/core/scss/components/_components.events.scss
@@ -139,7 +139,7 @@ a.dcf-c-calendar__date--active:focus {
 
   .dcf-c-events__listing {
     @include grid;
-    grid-template-columns: repeat(auto-fit, minmax(#{ms(20)}em, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(#{ms(20)}em, 1fr)); // 17.71em
     grid-area: listing;
   }
 
@@ -192,5 +192,5 @@ a.dcf-c-calendar__date--active:focus {
 
 
 .dcf-c-event__date-time {
-  flex: 0 1 #{ms(10)}em;
+  flex: 0 1 #{ms(10)}em; // 4.21em
 }

--- a/core/scss/components/_components.forms.scss
+++ b/core/scss/components/_components.forms.scss
@@ -11,10 +11,8 @@
 .dcf-c-input-textual {
   @include block;
   @include mt1;
-//   padding-top: .6em;
   @include pt2;
   @include pr3;
-//   padding-bottom: .4em;
   @include pb2;
   @include pl3;
   border: 1px solid $color-border;
@@ -95,10 +93,8 @@
 	@include w100;
 	@include m0;
 	outline: none;
-//   padding-top: .6em;
   @include pt2;
   @include pr4;
-//   padding-bottom: .4em;
   @include pb2;
   @include pl3;
 

--- a/core/scss/components/_components.headings.scss
+++ b/core/scss/components/_components.headings.scss
@@ -11,7 +11,7 @@
 .dcf-c-h5,
 .dcf-c-h6 {
   @include mt0;
-  margin-bottom: #{ms(0)}rem;
+  margin-bottom: #{ms(0)}rem; // 1rem
   @include lh2;
 
   // ?
@@ -30,5 +30,5 @@
   @include block;
   @include mb4;
   @include uppercase;
-  font-size: #{ms(-2)}rem;
+  font-size: #{ms(-2)}rem; // .75rem
 }

--- a/core/scss/components/_components.icons.scss
+++ b/core/scss/components/_components.icons.scss
@@ -3,21 +3,23 @@
 /////////////////////////////
 
 
-
 a .dcf-c-icon,
 button .dcf-c-icon {
   fill: currentcolor;
 }
 
+
 .dcf-c-icon--inline {
-  height: #{ms(0)}em;
-  width: #{ms(0)}em;
+  height: #{ms(0)}em; // 1em
+  width: #{ms(0)}em; // 1em
 }
+
 
 .dcf-c-icon--x {
   @include relative;
-  top: #{ms(-14)}em;
+  top: #{ms(-14)}em; // .13em
 }
+
 
 .dcf-c-icon--hang {
   @include absolute;

--- a/core/scss/components/_components.navigation.scss
+++ b/core/scss/components/_components.navigation.scss
@@ -5,8 +5,8 @@
 
 // !Skip Navigation
 .dcf-c-skipnav {
-  top: $length2;
-  left: $length2;
+  top: #{ms(-4)}em; // .56em
+  left: #{ms(-4)}em; // .56em
 }
 
 

--- a/core/scss/components/_components.paragraphs.scss
+++ b/core/scss/components/_components.paragraphs.scss
@@ -5,12 +5,12 @@
 
 // !Lead Paragraphs
 .dcf-c-lead {
-  font-size: #{ms(1)}em;
+  font-size: #{ms(1)}em; // 1.25em
 }
 
 
 // !Drop Caps
 .dcf-c-dropcap:first-letter {
   @include float-left;
-  // apply custom styling in _theme-typography
+  // apply custom styling in theme _components.paragraphs
 }

--- a/core/scss/components/_components.quotes.scss
+++ b/core/scss/components/_components.quotes.scss
@@ -14,14 +14,14 @@
 .dcf-c-blockquote::before {
   content: open-quote;
   @include absolute;
-  font-size: #{ms(16)}em;
+  font-size: #{ms(16)}em; // 9.97em
   @include lh1;
 }
 
 
 .dcf-c-blockquote p {
-  padding-top: #{ms(9)}em;
-  font-size: #{ms(2)}em;
+  padding-top: #{ms(9)}em; // 3.95em
+  font-size: #{ms(2)}em; // 1.33em
 }
 
 

--- a/core/scss/components/_components.search.scss
+++ b/core/scss/components/_components.search.scss
@@ -5,7 +5,7 @@
 
 // !Search Results
 .dcf-c-search-results-wrapper {
-  height: calc(100% - #{ms(16)}em);
+  height: calc(100% - #{ms(16)}em); // 100% - 9.97em
 }
 
 .dcf-c-search-results {
@@ -22,7 +22,7 @@
 
   @supports (display: grid) {
     @include grid;
-    grid-template-columns: repeat(auto-fit, minmax(#{ms(18)}em, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(#{ms(18)}em, 1fr)); // 13.29em
     grid-gap: #{ms(8)}em 5vw;
   }
 }

--- a/core/scss/elements/_elements.buttons.scss
+++ b/core/scss/elements/_elements.buttons.scss
@@ -13,7 +13,7 @@ input[type="submit"] {
   @include pr4;
   @include pb2;
   @include pl4;
-  font-size: #{ms(0)}em;
+  font-size: #{ms(0)}em; // 1em
   @include lh3;
 //   font-family: inherit;
 //   -webkit-appearance: none;

--- a/core/scss/elements/_elements.code.scss
+++ b/core/scss/elements/_elements.code.scss
@@ -12,10 +12,10 @@ pre {
 
 code,
 kbd {
-  padding-top: .125rem;
-  padding-right: .25rem;
-  padding-bottom: .125rem;
-  padding-left: .25rem;
+  padding-top: #{ms(-14)}rem; // .13em
+  padding-right: #{ms(-10)}rem; // .24em
+  padding-bottom: #{ms(-14)}rem; // .13em
+  padding-left: #{ms(-10)}rem; // .24em
   @include sm1;
 }
 

--- a/core/scss/elements/_elements.forms.scss
+++ b/core/scss/elements/_elements.forms.scss
@@ -6,7 +6,7 @@
 form,
 input,
 textarea {
-  font-size: 1em;
+  font-size: #{ms(0)}em; // 1em
   @include lh3;
 }
 
@@ -25,7 +25,6 @@ legend {
 
 label {
   @include inlineblock;
-//   @include mb1;
 }
 
 

--- a/core/scss/elements/_elements.headings.scss
+++ b/core/scss/elements/_elements.headings.scss
@@ -10,7 +10,7 @@ h4,
 h5,
 h6 {
   @include mt0;
-  margin-bottom: 1rem;
+  margin-bottom: #{ms(0)}rem; // 1rem
   @include lh2;
   color: $color-heading;
 
@@ -24,9 +24,9 @@ h6 {
 }
 
 
-h1 { font-size: #{ms(6)}em }
-h2 { font-size: #{ms(5)}em }
-h3 { font-size: #{ms(4)}em }
-h4 { font-size: #{ms(3)}em }
-h5 { font-size: #{ms(2)}em }
-h6 { font-size: #{ms(1)}em }
+h1 { font-size: #{ms(6)}em } // 2.37em
+h2 { font-size: #{ms(5)}em } // 2.22em
+h3 { font-size: #{ms(4)}em } // 1.77em
+h4 { font-size: #{ms(3)}em } // 1.66em
+h5 { font-size: #{ms(2)}em } // 1.33em
+h6 { font-size: #{ms(1)}em } // 1.25em

--- a/core/scss/elements/_elements.marks.scss
+++ b/core/scss/elements/_elements.marks.scss
@@ -5,9 +5,9 @@
 
 // Marked (highlighted) text
 mark {
-  padding-top: .125em;
+  padding-top: #{ms(-14)}em; // .13em
   @include pr1;
-  padding-bottom: .125em;
+  padding-bottom: #{ms(-14)}em; // .13em
   @include pl1;
   background-color: $color-mark;
 }

--- a/core/scss/elements/_elements.paragraphs.scss
+++ b/core/scss/elements/_elements.paragraphs.scss
@@ -6,7 +6,7 @@
 p {
   max-width: 36rem;
   @include mt0;
-  margin-bottom: 1rem;
+  margin-bottom: #{ms(0)}rem; // 1rem
 
 //   & + & {
 //     margin-top: 1.5em;

--- a/core/scss/elements/_elements.sup-sub.scss
+++ b/core/scss/elements/_elements.sup-sub.scss
@@ -14,11 +14,11 @@ sub {
 
 // !Superscript
 sup {
-  top: -#{ms(-4)}em;
+  top: -#{ms(-4)}em; // -.56em
 }
 
 
 // !Subscript
 sub {
-  top: #{ms(-10)}em;
+  top: #{ms(-10)}em; // .24em
 }

--- a/core/scss/mixins/_mixins.margins.scss
+++ b/core/scss/mixins/_mixins.margins.scss
@@ -14,6 +14,7 @@
 @mixin m7($imp:null) { margin: $length7 $imp; }
 @mixin m8($imp:null) { margin: $length8 $imp; }
 @mixin m9($imp:null) { margin: $length9 $imp; }
+@mixin m10($imp:null) { margin: $length10 $imp; }
 
 
 // !Top
@@ -27,6 +28,7 @@
 @mixin mt7($imp:null) { margin-top: $length7 $imp; }
 @mixin mt8($imp:null) { margin-top: $length8 $imp; }
 @mixin mt9($imp:null) { margin-top: $length9 $imp; }
+@mixin mt10($imp:null) { margin-top: $length10 $imp; }
 
 
 // !Right
@@ -40,6 +42,7 @@
 @mixin mr7($imp:null) { margin-right: $length7 $imp; }
 @mixin mr8($imp:null) { margin-right: $length8 $imp; }
 @mixin mr9($imp:null) { margin-right: $length9 $imp; }
+@mixin mr10($imp:null) { margin-right: $length10 $imp; }
 
 
 // !Bottom
@@ -53,6 +56,7 @@
 @mixin mb7($imp:null) { margin-bottom: $length7 $imp; }
 @mixin mb8($imp:null) { margin-bottom: $length8 $imp; }
 @mixin mb9($imp:null) { margin-bottom: $length9 $imp; }
+@mixin mb10($imp:null) { margin-bottom: $length10 $imp; }
 
 
 // !Left
@@ -66,3 +70,4 @@
 @mixin ml7($imp:null) { margin-left: $length7 $imp; }
 @mixin ml8($imp:null) { margin-left: $length8 $imp; }
 @mixin ml9($imp:null) { margin-left: $length9 $imp; }
+@mixin ml10($imp:null) { margin-left: $length10 $imp; }

--- a/core/scss/mixins/_mixins.padding.scss
+++ b/core/scss/mixins/_mixins.padding.scss
@@ -14,6 +14,7 @@
 @mixin p7($imp:null) { padding: $length7 $imp; }
 @mixin p8($imp:null) { padding: $length8 $imp; }
 @mixin p9($imp:null) { padding: $length9 $imp; }
+@mixin p10($imp:null) { padding: $length10 $imp; }
 
 
 // !Top
@@ -27,6 +28,7 @@
 @mixin pt7($imp:null) { padding-top: $length7 $imp; }
 @mixin pt8($imp:null) { padding-top: $length8 $imp; }
 @mixin pt9($imp:null) { padding-top: $length9 $imp; }
+@mixin pt10($imp:null) { padding-top: $length10 $imp; }
 
 
 // !Right
@@ -40,6 +42,7 @@
 @mixin pr7($imp:null) { padding-right: $length7 $imp; }
 @mixin pr8($imp:null) { padding-right: $length8 $imp; }
 @mixin pr9($imp:null) { padding-right: $length9 $imp; }
+@mixin pr10($imp:null) { padding-right: $length10 $imp; }
 
 
 // !Bottom
@@ -53,6 +56,7 @@
 @mixin pb7($imp:null) { padding-bottom: $length7 $imp; }
 @mixin pb8($imp:null) { padding-bottom: $length8 $imp; }
 @mixin pb9($imp:null) { padding-bottom: $length9 $imp; }
+@mixin pb10($imp:null) { padding-bottom: $length10 $imp; }
 
 
 // !Left
@@ -66,3 +70,4 @@
 @mixin pl7($imp:null) { padding-left: $length7 $imp; }
 @mixin pl8($imp:null) { padding-left: $length8 $imp; }
 @mixin pl9($imp:null) { padding-left: $length9 $imp; }
+@mixin pl10($imp:null) { padding-left: $length10 $imp; }

--- a/core/scss/utilities/_utilities.margins.scss
+++ b/core/scss/utilities/_utilities.margins.scss
@@ -14,6 +14,7 @@
 .dcf-u-m7 { @include m7(!important); }
 .dcf-u-m8 { @include m8(!important); }
 .dcf-u-m9 { @include m9(!important); }
+.dcf-u-m10 { @include m10(!important); }
 
 
 // !Top
@@ -27,6 +28,7 @@
 .dcf-u-mt7 { @include mt7(!important); }
 .dcf-u-mt8 { @include mt8(!important); }
 .dcf-u-mt9 { @include mt9(!important); }
+.dcf-u-mt10 { @include mt10(!important); }
 
 
 // !Right
@@ -40,6 +42,7 @@
 .dcf-u-mr7 { @include mr7(!important); }
 .dcf-u-mr8 { @include mr8(!important); }
 .dcf-u-mr9 { @include mr9(!important); }
+.dcf-u-mr10 { @include mr10(!important); }
 
 
 // !Bottom
@@ -53,6 +56,7 @@
 .dcf-u-mb7 { @include mb7(!important); }
 .dcf-u-mb8 { @include mb8(!important); }
 .dcf-u-mb9 { @include mb9(!important); }
+.dcf-u-mb10 { @include mb10(!important); }
 
 
 // !Left
@@ -66,3 +70,4 @@
 .dcf-u-ml7 { @include ml7(!important); }
 .dcf-u-ml8 { @include ml8(!important); }
 .dcf-u-ml9 { @include ml9(!important); }
+.dcf-u-ml10 { @include ml10(!important); }

--- a/core/scss/utilities/_utilities.padding.scss
+++ b/core/scss/utilities/_utilities.padding.scss
@@ -14,6 +14,7 @@
 .dcf-u-p7 { @include p7(!important); }
 .dcf-u-p8 { @include p8(!important); }
 .dcf-u-p9 { @include p9(!important); }
+.dcf-u-p10 { @include p10(!important); }
 
 
 // !Top
@@ -27,6 +28,7 @@
 .dcf-u-pt7 { @include pt7(!important); }
 .dcf-u-pt8 { @include pt8(!important); }
 .dcf-u-pt9 { @include pt9(!important); }
+.dcf-u-pt10 { @include pt10(!important); }
 
 
 // !Right
@@ -40,6 +42,7 @@
 .dcf-u-pr7 { @include pr7(!important); }
 .dcf-u-pr8 { @include pr8(!important); }
 .dcf-u-pr9 { @include pr9(!important); }
+.dcf-u-pr10 { @include pr10(!important); }
 
 
 // !Bottom
@@ -53,6 +56,7 @@
 .dcf-u-pb7 { @include pb7(!important); }
 .dcf-u-pb8 { @include pb8(!important); }
 .dcf-u-pb9 { @include pb9(!important); }
+.dcf-u-pb10 { @include pb10(!important); }
 
 
 // !Left
@@ -66,3 +70,4 @@
 .dcf-u-pl7 { @include pl7(!important); }
 .dcf-u-pl8 { @include pl8(!important); }
 .dcf-u-pl9 { @include pl9(!important); }
+.dcf-u-pl10 { @include pl10(!important); }

--- a/core/scss/variables/_variables.sizing.scss
+++ b/core/scss/variables/_variables.sizing.scss
@@ -7,7 +7,6 @@
 @import 'modularscale';
 
 $modularscale: (
-//   base: 1 1.075 1.155 1.241,
   base: 1 1.25,
   ratio: $fourth,
 );
@@ -25,12 +24,13 @@ $max_lerp_width: ms(36); // 176.581em ~ 2825.28px
 
 // !Spacing
 $length0: 0;
-$length1: #{ms(-6)}em; // .42em
-$length2: #{ms(-4)}em; // .56em
-$length3: #{ms(-2)}em; // .75em
-$length4: #{ms(0)}em;  // 1em
-$length5: #{ms(2)}em;  // 1.33em
-$length6: #{ms(4)}em;  // 1.77em
-$length7: #{ms(6)}em;  // 2.37em
-$length8: #{ms(8)}em;  // 3.16em
+$length1: #{ms(-6)}em;  // .42em
+$length2: #{ms(-4)}em;  // .56em
+$length3: #{ms(-2)}em;  // .75em
+$length4: #{ms(0)}em;   // 1em
+$length5: #{ms(2)}em;   // 1.33em
+$length6: #{ms(4)}em;   // 1.77em
+$length7: #{ms(6)}em;   // 2.37em
+$length8: #{ms(8)}em;   // 3.16em
 $length9: #{ms(10)}em;  // 4.21em
+$length10: #{ms(12)}em; // 5.61em

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -1777,6 +1777,9 @@ a.dcf-u-inverse:active {
 .dcf-u-m9 {
   margin: 4.21399em !important; }
 
+.dcf-u-m10 {
+  margin: 5.61866em !important; }
+
 .dcf-u-mt0 {
   margin-top: 0 !important; }
 
@@ -1806,6 +1809,9 @@ a.dcf-u-inverse:active {
 
 .dcf-u-mt9 {
   margin-top: 4.21399em !important; }
+
+.dcf-u-mt10 {
+  margin-top: 5.61866em !important; }
 
 .dcf-u-mr0 {
   margin-right: 0 !important; }
@@ -1837,6 +1843,9 @@ a.dcf-u-inverse:active {
 .dcf-u-mr9 {
   margin-right: 4.21399em !important; }
 
+.dcf-u-mr10 {
+  margin-right: 5.61866em !important; }
+
 .dcf-u-mb0 {
   margin-bottom: 0 !important; }
 
@@ -1867,6 +1876,9 @@ a.dcf-u-inverse:active {
 .dcf-u-mb9 {
   margin-bottom: 4.21399em !important; }
 
+.dcf-u-mb10 {
+  margin-bottom: 5.61866em !important; }
+
 .dcf-u-ml0 {
   margin-left: 0 !important; }
 
@@ -1896,6 +1908,9 @@ a.dcf-u-inverse:active {
 
 .dcf-u-ml9 {
   margin-left: 4.21399em !important; }
+
+.dcf-u-ml10 {
+  margin-left: 5.61866em !important; }
 
 @supports (object-fit: contain) {
   .dcf-u-objfit-contain {
@@ -2024,6 +2039,9 @@ a.dcf-u-inverse:active {
 .dcf-u-p9 {
   padding: 4.21399em !important; }
 
+.dcf-u-p10 {
+  padding: 5.61866em !important; }
+
 .dcf-u-pt0 {
   padding-top: 0 !important; }
 
@@ -2053,6 +2071,9 @@ a.dcf-u-inverse:active {
 
 .dcf-u-pt9 {
   padding-top: 4.21399em !important; }
+
+.dcf-u-pt10 {
+  padding-top: 5.61866em !important; }
 
 .dcf-u-pr0 {
   padding-right: 0 !important; }
@@ -2084,6 +2105,9 @@ a.dcf-u-inverse:active {
 .dcf-u-pr9 {
   padding-right: 4.21399em !important; }
 
+.dcf-u-pr10 {
+  padding-right: 5.61866em !important; }
+
 .dcf-u-pb0 {
   padding-bottom: 0 !important; }
 
@@ -2114,6 +2138,9 @@ a.dcf-u-inverse:active {
 .dcf-u-pb9 {
   padding-bottom: 4.21399em !important; }
 
+.dcf-u-pb10 {
+  padding-bottom: 5.61866em !important; }
+
 .dcf-u-pl0 {
   padding-left: 0 !important; }
 
@@ -2143,6 +2170,9 @@ a.dcf-u-inverse:active {
 
 .dcf-u-pl9 {
   padding-left: 4.21399em !important; }
+
+.dcf-u-pl10 {
+  padding-left: 5.61866em !important; }
 
 .dcf-u-static {
   position: static !important; }

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -92,10 +92,10 @@ pre {
 
 code,
 kbd {
-  padding-top: .125rem;
-  padding-right: .25rem;
-  padding-bottom: .125rem;
-  padding-left: .25rem;
+  padding-top: 0.13348rem;
+  padding-right: 0.2373rem;
+  padding-bottom: 0.13348rem;
+  padding-left: 0.2373rem;
   font-size: 0.9375em; }
 
 code,
@@ -271,6 +271,13 @@ dd + dt {
 
 main:focus {
   outline: none; }
+
+mark {
+  padding-top: 0.13348em;
+  padding-right: 0.42188em;
+  padding-bottom: 0.13348em;
+  padding-left: 0.42188em;
+  background-color: #ff0; }
 
 p {
   max-width: 36rem;

--- a/theme/example/scss/all.scss
+++ b/theme/example/scss/all.scss
@@ -68,6 +68,7 @@
 @import '../../../core/scss/elements/elements.images';
 @import '../../../core/scss/elements/elements.lists';
 @import '../../../core/scss/elements/elements.main';
+@import '../../../core/scss/elements/elements.marks';
 @import '../../../core/scss/elements/elements.paragraphs';
 @import '../../../core/scss/elements/elements.quotes';
 @import '../../../core/scss/elements/elements.small';

--- a/theme/example/scss/components/_components.footer.scss
+++ b/theme/example/scss/components/_components.footer.scss
@@ -20,14 +20,14 @@
   .example .dcf-c-footer__local {
 
     @include grid;
-    grid-template-columns: repeat(auto-fit, minmax(#{ms(18)}em, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(#{ms(18)}em, 1fr)); // 13.29em
 
   }
 
   .example .dcf-c-footer__global {
 
     @include grid;
-    grid-template-columns: repeat(auto-fit, minmax(#{ms(18)}em, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(#{ms(18)}em, 1fr)); // 13.29em
 
   }
 
@@ -51,7 +51,7 @@
 @include mq(md, max, width) {
 
   .example .dcf-c-footer__global {
-    padding-bottom: #{ms(12)}em;
+    padding-bottom: #{ms(12)}em; // 5.61em
   }
 
 }

--- a/theme/example/scss/components/_components.icons.scss
+++ b/theme/example/scss/components/_components.icons.scss
@@ -4,5 +4,5 @@
 
 
 .example .dcf-c-icon--hang {
-  top: #{ms(-12)}rem;
+  top: #{ms(-12)}rem; // -.18rem
 }

--- a/theme/example/scss/components/_components.paragraphs.scss
+++ b/theme/example/scss/components/_components.paragraphs.scss
@@ -4,9 +4,9 @@
 
 
 .example .dcf-c-dropcap:first-letter {
-  margin-top: #{ms(-4)}rem; // first, adjust margin-top for Firefox
-  padding-right: #{ms(-4)}rem;
-  padding-left: #{ms(-20)}rem;
-  font-size: #{ms(11)}em;
+  margin-top: #{ms(-4)}rem; // .56rem -- first, adjust margin-top for Firefox
+  padding-right: #{ms(-4)}rem; // .56rem
+  padding-left: #{ms(-20)}rem; // .06rem
+  font-size: #{ms(11)}em; // 5.26em
   line-height: .68; // then, adjust line-height for Chrome and Safari
 }


### PR DESCRIPTION
- Add additional length for margin & padding
- Remove commented-out styled no longer needed
- Avoid a mix of modular scale function values (#{ms(1)}) and length variables ($length1). The length variables do not contain all the possible values generated by the modular scale function and should be reserved for margin and padding mixins/utilities. Instead, use modular scale function for layout values for code consistency.
- Add comments that include reference values for properties that use modular scale function
- Add _elements.marks to all.scss