### PR TITLE
Rearchitect import of Sass partials

### DIFF
--- a/core/scss/components/components.scss
+++ b/core/scss/components/components.scss
@@ -1,0 +1,33 @@
+/////////////////////
+// !CORE / COMPONENTS
+/////////////////////
+
+
+@import 'components.alerts';
+@import 'components.anchors';
+@import 'components.articles';
+@import 'components.badges';
+@import 'components.breadcrumbs';
+@import 'components.button-groups';
+@import 'components.buttons';
+@import 'components.cards';
+@import 'components.code';
+@import 'components.events';
+@import 'components.figures';
+@import 'components.footer';
+@import 'components.forms';
+@import 'components.header';
+@import 'components.headings';
+@import 'components.heroes';
+@import 'components.icons';
+@import 'components.idm';
+@import 'components.input-groups';
+@import 'components.list-groups';
+@import 'components.lists';
+@import 'components.media-objects';
+@import 'components.modals';
+@import 'components.navigation';
+@import 'components.paragraphs';
+@import 'components.quotes';
+@import 'components.search';
+@import 'components.tables';

--- a/core/scss/elements/elements.scss
+++ b/core/scss/elements/elements.scss
@@ -1,0 +1,23 @@
+///////////////////
+// !CORE / ELEMENTS
+///////////////////
+
+
+@import 'elements.abbreviations';
+@import 'elements.addresses';
+@import 'elements.anchors';
+@import 'elements.body';
+@import 'elements.buttons';
+@import 'elements.code';
+@import 'elements.figures';
+@import 'elements.forms';
+@import 'elements.headings';
+@import 'elements.images';
+@import 'elements.lists';
+@import 'elements.main';
+@import 'elements.marks';
+@import 'elements.paragraphs';
+@import 'elements.quotes';
+@import 'elements.small';
+@import 'elements.sup-sub';
+@import 'elements.tables';

--- a/core/scss/functions/functions.scss
+++ b/core/scss/functions/functions.scss
@@ -1,0 +1,6 @@
+////////////////////
+// !CORE / FUNCTIONS
+////////////////////
+
+
+@import 'functions.media-queries';

--- a/core/scss/generic/generic.scss
+++ b/core/scss/generic/generic.scss
@@ -1,0 +1,7 @@
+//////////////////
+// !CORE / GENERIC
+//////////////////
+
+
+@import 'generic.box-sizing';
+@import 'generic.font-size';

--- a/core/scss/mixins/mixins.scss
+++ b/core/scss/mixins/mixins.scss
@@ -1,0 +1,25 @@
+/////////////////
+// !CORE / MIXINS
+/////////////////
+
+
+@import 'mixins.aspect-ratios';
+@import 'mixins.backgrounds';
+@import 'mixins.borders';
+@import 'mixins.box-alignment';
+@import 'mixins.colors';
+@import 'mixins.media-queries';
+@import 'mixins.disabled';
+@import 'mixins.display';
+@import 'mixins.flexbox';
+@import 'mixins.floats';
+@import 'mixins.grid';
+@import 'mixins.height-width';
+@import 'mixins.margins';
+@import 'mixins.object-fit';
+@import 'mixins.order';
+@import 'mixins.overflow';
+@import 'mixins.padding';
+@import 'mixins.position';
+@import 'mixins.typography';
+@import 'mixins.visibility';

--- a/core/scss/objects/objects.scss
+++ b/core/scss/objects/objects.scss
@@ -1,0 +1,9 @@
+//////////////////
+// !CORE / OBJECTS
+//////////////////
+
+
+@import 'objects.wrapper';
+@import 'objects.grid';
+@import 'objects.full-width';
+@import 'objects.media';

--- a/core/scss/utilities/utilities.scss
+++ b/core/scss/utilities/utilities.scss
@@ -1,0 +1,24 @@
+////////////////////
+// !CORE / UTILITIES
+////////////////////
+
+
+@import 'utilities.aspect-ratios';
+@import 'utilities.backgrounds';
+@import 'utilities.borders';
+@import 'utilities.box-alignment';
+@import 'utilities.colors';
+@import 'utilities.disabled';
+@import 'utilities.display';
+@import 'utilities.flexbox';
+@import 'utilities.floats';
+@import 'utilities.grid';
+@import 'utilities.height-width';
+@import 'utilities.margins';
+@import 'utilities.object-fit';
+@import 'utilities.order';
+@import 'utilities.overflow';
+@import 'utilities.padding';
+@import 'utilities.position';
+@import 'utilities.typography';
+@import 'utilities.visibility';

--- a/core/scss/variables/variables.scss
+++ b/core/scss/variables/variables.scss
@@ -1,0 +1,11 @@
+////////////////////
+// !CORE / VARIABLES
+////////////////////
+
+
+@import 'variables.borders';
+@import 'variables.breakpoints';
+@import 'variables.colors';
+@import 'variables.sizing';
+@import 'variables.transitions';
+@import 'variables.z-index';

--- a/theme/example/scss/all.scss
+++ b/theme/example/scss/all.scss
@@ -3,116 +3,36 @@
 ///////
 
 
-// !Core Variables
-@import '../../../core/scss/variables/variables.borders';
-@import '../../../core/scss/variables/variables.breakpoints';
-@import '../../../core/scss/variables/variables.colors';
-@import '../../../core/scss/variables/variables.sizing';
-@import '../../../core/scss/variables/variables.transitions';
-@import '../../../core/scss/variables/variables.z-index';
-
-// !Theme Variables
+// !Variables
+@import '../../../core/scss/variables/variables';
 @import 'variables/variables.colors';
 
 
-// !Core Mixins
-@import '../../../core/scss/mixins/mixins.aspect-ratios';
-@import '../../../core/scss/mixins/mixins.backgrounds';
-@import '../../../core/scss/mixins/mixins.borders';
-@import '../../../core/scss/mixins/mixins.box-alignment';
-@import '../../../core/scss/mixins/mixins.colors';
-@import '../../../core/scss/mixins/mixins.media-queries';
-@import '../../../core/scss/mixins/mixins.disabled';
-@import '../../../core/scss/mixins/mixins.display';
-@import '../../../core/scss/mixins/mixins.flexbox';
-@import '../../../core/scss/mixins/mixins.floats';
-@import '../../../core/scss/mixins/mixins.grid';
-@import '../../../core/scss/mixins/mixins.height-width';
-@import '../../../core/scss/mixins/mixins.margins';
-@import '../../../core/scss/mixins/mixins.object-fit';
-@import '../../../core/scss/mixins/mixins.order';
-@import '../../../core/scss/mixins/mixins.overflow';
-@import '../../../core/scss/mixins/mixins.padding';
-@import '../../../core/scss/mixins/mixins.position';
-@import '../../../core/scss/mixins/mixins.typography';
-@import '../../../core/scss/mixins/mixins.visibility';
-
-// !Theme Mixins
+// !Mixins
+@import '../../../core/scss/mixins/mixins';
 @import 'mixins/mixins.backgrounds';
 @import 'mixins/mixins.fonts';
 
 
-// !Core Functions
-@import '../../../core/scss/functions/functions.media-queries';
+// !Functions
+@import '../../../core/scss/functions/functions';
 
 
-// !Core Generic
-@import '../../../core/scss/generic/generic.box-sizing';
-@import '../../../core/scss/generic/generic.font-size';
-
-// !Theme Generic
+// !Generic
+@import '../../../core/scss/generic/generic';
 @import 'generic/generic.base';
 
 
-// !Core Elements
-@import '../../../core/scss/elements/elements.abbreviations';
-@import '../../../core/scss/elements/elements.addresses';
-@import '../../../core/scss/elements/elements.anchors';
-@import '../../../core/scss/elements/elements.body';
-@import '../../../core/scss/elements/elements.buttons';
-@import '../../../core/scss/elements/elements.code';
-@import '../../../core/scss/elements/elements.figures';
-@import '../../../core/scss/elements/elements.forms';
-@import '../../../core/scss/elements/elements.headings';
-@import '../../../core/scss/elements/elements.images';
-@import '../../../core/scss/elements/elements.lists';
-@import '../../../core/scss/elements/elements.main';
-@import '../../../core/scss/elements/elements.marks';
-@import '../../../core/scss/elements/elements.paragraphs';
-@import '../../../core/scss/elements/elements.quotes';
-@import '../../../core/scss/elements/elements.small';
-@import '../../../core/scss/elements/elements.sup-sub';
-@import '../../../core/scss/elements/elements.tables';
+// !Elements
+@import '../../../core/scss/elements/elements';
 
 
-// !Core Objects
-@import '../../../core/scss/objects/objects.wrapper';
-@import '../../../core/scss/objects/objects.grid';
-@import '../../../core/scss/objects/objects.full-width';
-@import '../../../core/scss/objects/objects.media';
+// !Objects
+@import '../../../core/scss/objects/objects';
 
 
-// !Core Components
-@import '../../../core/scss/components/components.alerts';
-@import '../../../core/scss/components/components.anchors';
-@import '../../../core/scss/components/components.articles';
-@import '../../../core/scss/components/components.badges';
-@import '../../../core/scss/components/components.breadcrumbs';
-@import '../../../core/scss/components/components.button-groups';
-@import '../../../core/scss/components/components.buttons';
-@import '../../../core/scss/components/components.cards';
-@import '../../../core/scss/components/components.code';
-@import '../../../core/scss/components/components.events';
-@import '../../../core/scss/components/components.figures';
-@import '../../../core/scss/components/components.footer';
-@import '../../../core/scss/components/components.forms';
-@import '../../../core/scss/components/components.header';
-@import '../../../core/scss/components/components.headings';
-@import '../../../core/scss/components/components.heroes';
-@import '../../../core/scss/components/components.icons';
-@import '../../../core/scss/components/components.idm';
-@import '../../../core/scss/components/components.input-groups';
-@import '../../../core/scss/components/components.list-groups';
-@import '../../../core/scss/components/components.lists';
-@import '../../../core/scss/components/components.media-objects';
-@import '../../../core/scss/components/components.modals';
-@import '../../../core/scss/components/components.navigation';
-@import '../../../core/scss/components/components.paragraphs';
-@import '../../../core/scss/components/components.quotes';
-@import '../../../core/scss/components/components.search';
-@import '../../../core/scss/components/components.tables';
-
-// !Theme Components
+// !Components
+@import '../../../core/scss/components/components';
 @import 'components/components.breadcrumbs';
 @import 'components/components.button-groups';
 @import 'components/components.buttons';
@@ -126,27 +46,7 @@
 @import 'components/components.paragraphs';
 
 
-// !Core Utilities
-@import '../../../core/scss/utilities/utilities.aspect-ratios';
-@import '../../../core/scss/utilities/utilities.backgrounds';
-@import '../../../core/scss/utilities/utilities.borders';
-@import '../../../core/scss/utilities/utilities.box-alignment';
-@import '../../../core/scss/utilities/utilities.colors';
-@import '../../../core/scss/utilities/utilities.disabled';
-@import '../../../core/scss/utilities/utilities.display';
-@import '../../../core/scss/utilities/utilities.flexbox';
-@import '../../../core/scss/utilities/utilities.floats';
-@import '../../../core/scss/utilities/utilities.grid';
-@import '../../../core/scss/utilities/utilities.height-width';
-@import '../../../core/scss/utilities/utilities.margins';
-@import '../../../core/scss/utilities/utilities.object-fit';
-@import '../../../core/scss/utilities/utilities.order';
-@import '../../../core/scss/utilities/utilities.overflow';
-@import '../../../core/scss/utilities/utilities.padding';
-@import '../../../core/scss/utilities/utilities.position';
-@import '../../../core/scss/utilities/utilities.typography';
-@import '../../../core/scss/utilities/utilities.visibility';
-
-// !Theme Utilities
+// !Utilities
+@import '../../../core/scss/utilities/utilities';
 @import 'utilities/utilities.backgrounds';
 @import 'utilities/utilities.fonts';


### PR DESCRIPTION
Import core partials at the ITCSS layer level. If core partials are later added or removed, theme owners will no longer be required to manually add or remove the individual @imports to their theme’s all.scss file.