### PR TITLE
Remove media object margins

### DIFF
--- a/core/scss/objects/_objects.media.scss
+++ b/core/scss/objects/_objects.media.scss
@@ -12,15 +12,3 @@
 .dcf-o-media__body {
   flex: 1;
 }
-
-
-// Media object (usually an image) on left
-.dcf-o-media__object.dcf-u-1st {
-  @include mr5;
-}
-
-
-// Media object (usually an image) on right
-.dcf-o-media__object.dcf-u-2nd {
-  @include ml5;
-}

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -712,12 +712,6 @@ th {
   -webkit-box-flex: 1;
           flex: 1; }
 
-.dcf-o-media__object.dcf-u-1st {
-  margin-right: 1.33333em; }
-
-.dcf-o-media__object.dcf-u-2nd {
-  margin-left: 1.33333em; }
-
 .dcf-c-alert {
   display: grid;
   grid-template-areas: "header footer" "msg footer"; }


### PR DESCRIPTION
Because of the wide variety of uses for this object, I've removed the margin styles and recommend  using whichever margin utility classes best serve the layout.