### PR TITLE
Core input group updates

### DIFF
--- a/core/scss/components/_components.input-groups.scss
+++ b/core/scss/components/_components.input-groups.scss
@@ -10,8 +10,8 @@
 
 
 // !Input Group Input Field
-.dcf-c-input-group .dcf-c-input-textual {
-  flex: 1 1 auto;
+.dcf-c-input-group .dcf-c-input-text {
+  @include flex-grow1;
   width: 1%;
   @include mt0;
   @include mb0;
@@ -28,7 +28,7 @@
 
 
 // !Input Group Add-on
-.dcf-c-input-group-addon {
+.dcf-c-input-group__addon {
   @include flex;
   @include ai-center;
   @include txt-nowrap;

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -1165,9 +1165,9 @@ button .dcf-c-icon {
   display: flex;
   width: 100%; }
 
-.dcf-c-input-group .dcf-c-input-textual {
+.dcf-c-input-group .dcf-c-input-text {
   -webkit-box-flex: 1;
-          flex: 1 1 auto;
+          flex-grow: 1;
   width: 1%;
   margin-top: 0;
   margin-bottom: 0; }
@@ -1180,7 +1180,7 @@ button .dcf-c-icon {
   margin-top: 0;
   margin-bottom: 0; }
 
-.dcf-c-input-group-addon {
+.dcf-c-input-group__addon {
   display: -webkit-box;
   display: flex;
   -webkit-box-align: center;


### PR DESCRIPTION
This should have been included with #52

- Use BEM syntax for input group add-ons
- Shorten ‘-input-textual’ to ‘-input-text’
- Use flex-grow1 mixin for input group text input