### PR TITLE
Table styling updates

### DIFF
--- a/core/scss/components/_components.tables.scss
+++ b/core/scss/components/_components.tables.scss
@@ -3,57 +3,37 @@
 //////////////////////////////
 
 
-.dcf-c-table {
+// .dcf-c-table {
 //   display: block; // !responsive by default?
 //   @include w100;
 //   max-width: 100%;
 //   overflow-x: auto; // !responsive by default?
-  @include sm1;
-}
+// }
 
 
 .dcf-c-table thead,
 .dcf-c-table tbody {
+  @include sm1;
   @include bb;
   border-color: $color-border;
 }
 
 
-// .dcf-c-table thead {
-//   @include uppercase;
-// }
-
-// .dcf-c-table th,
-// .dcf-c-table td {
-//   border-top: 1px solid $color-border;
-// }
-
-
-// .dcf-c-table thead th {
-//   border-bottom: 2px solid #ddd;
-// }
-
-
-// .dcf-c-table thead th,
-// .dcf-c-table thead td {
-// //   padding-top: 1.25em;
-//   @include pb4;
-// //   @include pl4;
-// }
-
-
 .dcf-c-table thead th,
 .dcf-c-table thead td {
-  @include pb3;
   @include txt-bottom;
 }
 
 
 .dcf-c-table tbody th,
 .dcf-c-table tbody td {
-//   @include pt4;
-  @include pb4;
   @include txt-top;
+}
+
+
+.dcf-c-table--standard thead th,
+.dcf-c-table--standard thead td {
+  @include pb3;
 }
 
 
@@ -63,9 +43,21 @@
 }
 
 
+.dcf-c-table--standard tbody th,
+.dcf-c-table--standard tbody td {
+  @include pb4;
+}
+
+
 .dcf-c-table--compact tbody th,
 .dcf-c-table--compact tbody td {
   @include pb3;
+}
+
+
+.dcf-c-table--standard th:not(:last-child),
+.dcf-c-table--standard td:not(:last-child) {
+  @include pr5;
 }
 
 
@@ -75,10 +67,9 @@
 }
 
 
-//
-.dcf-c-table th:not(:last-child),
-.dcf-c-table td:not(:last-child) {
-  @include pr5;
+.dcf-c-table--standard tbody tr:first-child th,
+.dcf-c-table--standard tbody tr:first-child td {
+  @include pt4;
 }
 
 
@@ -88,25 +79,13 @@
 }
 
 
-// .dcf-c-table--compact tbody th,
-// .dcf-c-table--compact tbody td {
-//   @include pb2;
-// }
-
-
-.dcf-c-table tbody tr:first-child th,
-.dcf-c-table tbody tr:first-child td {
-  @include pt4;
-}
-
-
-// !Striped Table
+// !Striped Table?
 // .dcf-c-table-striped tbody tr:nth-of-type(odd) {
 //   background-color: rgba(0,0,0,.05);
 // }
 
 
-// !Bordered Table
+// !Bordered Table?
 // .dcf-c-table-bordered,
 // .dcf-c-table-bordered th,
 // .dcf-c-table-bordered td {
@@ -114,13 +93,13 @@
 // }
 
 
-// !Hoverable Rows
+// !Hoverable Rows?
 // .dcf-c-table-hover tbody tr:hover {
 //   background-color: $color-active;
 // }
 
 
-// !Contextual Colors
+// !Contextual Colors?
 // .dcf-c-table-active {
 //   background-color: $color-active;
 // }

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -1348,48 +1348,52 @@ button .dcf-c-icon {
     .dcf-c-search-results__directory {
       grid-area: directory; } } }
 
-.dcf-c-table {
-  font-size: 0.84375em; }
-
 .dcf-c-table thead,
 .dcf-c-table tbody {
+  font-size: 0.84375em;
   border-bottom-style: solid;
   border-bottom-width: 1px;
   border-color: #d0d0d0; }
 
 .dcf-c-table thead th,
 .dcf-c-table thead td {
-  padding-bottom: 0.75em;
   vertical-align: bottom; }
 
 .dcf-c-table tbody th,
 .dcf-c-table tbody td {
-  padding-bottom: 1em;
   vertical-align: top; }
+
+.dcf-c-table--standard thead th,
+.dcf-c-table--standard thead td {
+  padding-bottom: 0.75em; }
 
 .dcf-c-table--compact thead th,
 .dcf-c-table--compact thead td {
   padding-bottom: 0.5625em; }
 
+.dcf-c-table--standard tbody th,
+.dcf-c-table--standard tbody td {
+  padding-bottom: 1em; }
+
 .dcf-c-table--compact tbody th,
 .dcf-c-table--compact tbody td {
   padding-bottom: 0.75em; }
+
+.dcf-c-table--standard th:not(:last-child),
+.dcf-c-table--standard td:not(:last-child) {
+  padding-right: 1.33333em; }
 
 .dcf-c-table--compact th:not(:last-child),
 .dcf-c-table--compact td:not(:last-child) {
   padding-right: 1em; }
 
-.dcf-c-table th:not(:last-child),
-.dcf-c-table td:not(:last-child) {
-  padding-right: 1.33333em; }
+.dcf-c-table--standard tbody tr:first-child th,
+.dcf-c-table--standard tbody tr:first-child td {
+  padding-top: 1em; }
 
 .dcf-c-table--compact tbody tr:first-child th,
 .dcf-c-table--compact tbody tr:first-child td {
   padding-top: 0.75em; }
-
-.dcf-c-table tbody tr:first-child th,
-.dcf-c-table tbody tr:first-child td {
-  padding-top: 1em; }
 
 .example .dcf-c-breadcrumbs li:not(:last-child) {
   margin-right: 0.75em; }


### PR DESCRIPTION
- Move table font-size to th and td elements to keep table caption value in modular scale
- Move unique styles to new “—standard” modifier classes to avoid overrides by the “—compact” modifier
- Remove or comment out unused styles
- Edit comments