### PR TITLE
SCSS architecture updates: JS styles, keyframes

### DIFF
--- a/core/scss/elements/_elements.dialog.scss
+++ b/core/scss/elements/_elements.dialog.scss
@@ -3,21 +3,6 @@
 ////////////////////////////
 
 
-@keyframes appear {
-
-  0% {
-    opacity: 0;
-    transform: scale(.9);
-  }
-
-  100% {
-    opacity: 1;
-    transform: scale(1);
-  }
-
-}
-
-
 dialog {
   width: 80vw; // restrict width when browser doesn't support fit-content
   padding: 0; // force padding 0 otherwise click close will not work accurately

--- a/core/scss/elements/elements.scss
+++ b/core/scss/elements/elements.scss
@@ -10,6 +10,7 @@
 @import 'elements.body';
 @import 'elements.buttons';
 @import 'elements.code';
+@import 'elements.dialog';
 @import 'elements.figures';
 @import 'elements.forms';
 @import 'elements.headings';

--- a/core/scss/generic/_generic.keyframes.scss
+++ b/core/scss/generic/_generic.keyframes.scss
@@ -1,0 +1,19 @@
+//////////////////////////////
+// !CORE / GENERIC / KEYFRAMES
+//////////////////////////////
+
+
+// !Appear
+@keyframes appear {
+
+  0% {
+    opacity: 0;
+    transform: scale(.9);
+  }
+
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+
+}

--- a/core/scss/generic/_generic.keyframes.scss
+++ b/core/scss/generic/_generic.keyframes.scss
@@ -17,3 +17,19 @@
   }
 
 }
+
+
+// !Fade Up
+@keyframes fade-up {
+
+  0% {
+    opacity: 0;
+    transform: translateY(50%);
+  }
+
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+}

--- a/core/scss/generic/generic.scss
+++ b/core/scss/generic/generic.scss
@@ -5,3 +5,4 @@
 
 @import 'generic.box-sizing';
 @import 'generic.font-size';
+@import 'generic.keyframes';

--- a/core/scss/javascript/_javascript.dialog.scss
+++ b/core/scss/javascript/_javascript.dialog.scss
@@ -1,0 +1,9 @@
+//////////////////////////////
+// !CORE / JAVASCRIPT / DIALOG
+//////////////////////////////
+
+
+// Dialog polyfill styles
+.dcf-js-dialog .backdrop {
+  @include bg-overlay-dark;
+}

--- a/core/scss/javascript/_javascript.states.scss
+++ b/core/scss/javascript/_javascript.states.scss
@@ -1,0 +1,8 @@
+//////////////////////////////
+// !CORE / JAVASCRIPT / STATES
+//////////////////////////////
+
+
+.dcf-js-fade-up {
+  animation: fade-up 2s forwards ease-out;
+}

--- a/core/scss/javascript/javascript.scss
+++ b/core/scss/javascript/javascript.scss
@@ -4,3 +4,4 @@
 
 
 @import 'javascript.dialog';
+@import 'javascript.states';

--- a/core/scss/javascript/javascript.scss
+++ b/core/scss/javascript/javascript.scss
@@ -1,0 +1,6 @@
+/////////////////////
+// !CORE / JAVASCRIPT
+/////////////////////
+
+
+@import 'javascript.dialog';

--- a/core/scss/js/_js.dialog.scss
+++ b/core/scss/js/_js.dialog.scss
@@ -1,2 +1,0 @@
-// Dialog polyfill styles
-.dcf-js-dialog .backdrop { @include bg-overlay-dark; }

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -24,6 +24,26 @@
   :root {
     font-size: 1.33333em; } }
 
+@-webkit-keyframes appear {
+  0% {
+    opacity: 0;
+    -webkit-transform: scale(0.9);
+            transform: scale(0.9); }
+  100% {
+    opacity: 1;
+    -webkit-transform: scale(1);
+            transform: scale(1); } }
+
+@keyframes appear {
+  0% {
+    opacity: 0;
+    -webkit-transform: scale(0.9);
+            transform: scale(0.9); }
+  100% {
+    opacity: 1;
+    -webkit-transform: scale(1);
+            transform: scale(1); } }
+
 html {
   font-family: system; }
 

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -44,6 +44,26 @@
     -webkit-transform: scale(1);
             transform: scale(1); } }
 
+@-webkit-keyframes fade-up {
+  0% {
+    opacity: 0;
+    -webkit-transform: translateY(50%);
+            transform: translateY(50%); }
+  100% {
+    opacity: 1;
+    -webkit-transform: translateY(0);
+            transform: translateY(0); } }
+
+@keyframes fade-up {
+  0% {
+    opacity: 0;
+    -webkit-transform: translateY(50%);
+            transform: translateY(50%); }
+  100% {
+    opacity: 1;
+    -webkit-transform: translateY(0);
+            transform: translateY(0); } }
+
 html {
   font-family: system; }
 
@@ -1753,6 +1773,18 @@ button .dcf-c-icon {
   padding-left: 0.05631rem;
   font-size: 4.74074em;
   line-height: 0.63281; }
+
+.dcf-js-dialog .backdrop {
+  background-color: rgba(0, 0, 0, 0.96); }
+  @supports ((-webkit-backdrop-filter: blur(6px)) or (backdrop-filter: blur(6px))) {
+    .dcf-js-dialog .backdrop {
+      background-color: rgba(0, 0, 0, 0.8);
+      -webkit-backdrop-filter: blur(6px) grayscale(10%);
+              backdrop-filter: blur(6px) grayscale(10%); } }
+
+.dcf-js-fade-up {
+  -webkit-animation: fade-up 2s forwards ease-out;
+          animation: fade-up 2s forwards ease-out; }
 
 .dcf-u-ratio {
   display: block;

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -148,6 +148,30 @@ kbd kbd {
   padding: 0;
   font-size: 100%; }
 
+dialog {
+  width: 80vw;
+  padding: 0;
+  border: none !important;
+  background-color: transparent;
+  -webkit-transform-origin: center;
+          transform-origin: center; }
+  dialog::-webkit-backdrop {
+    background-color: rgba(0, 0, 0, 0.96); }
+  dialog::backdrop {
+    background-color: rgba(0, 0, 0, 0.96); }
+    @supports ((-webkit-backdrop-filter: blur(6px)) or (backdrop-filter: blur(6px))) {
+      dialog::-webkit-backdrop {
+        background-color: rgba(0, 0, 0, 0.8);
+        -webkit-backdrop-filter: blur(6px) grayscale(10%);
+                backdrop-filter: blur(6px) grayscale(10%); }
+      dialog::backdrop {
+        background-color: rgba(0, 0, 0, 0.8);
+        -webkit-backdrop-filter: blur(6px) grayscale(10%);
+                backdrop-filter: blur(6px) grayscale(10%); } }
+  dialog[open] {
+    -webkit-animation: appear 300ms forwards ease-out;
+            animation: appear 300ms forwards ease-out; }
+
 figure {
   margin: 0; }
 

--- a/theme/example/scss/all.scss
+++ b/theme/example/scss/all.scss
@@ -47,6 +47,10 @@
 @import 'components/components.paragraphs';
 
 
+// !JavaScript
+@import '../../../core/scss/javascript/javascript';
+
+
 // !Utilities
 @import '../../../core/scss/utilities/utilities';
 @import 'utilities/utilities.backgrounds';


### PR DESCRIPTION
- Rename Sass ‘js’ directory & files ‘javascript’ for consistency with sibling directories
- Move "appear" keyframes from dialog element to new file in generic directory, and add "fade-up" keyframes
- Import/output dialog element styles
- Add JavaScript-controlled styles for states
- Import JavaScript-based styles in example theme