### PR TITLE
Bug fixes

### DIFF
--- a/core/scss/components/_components.header.scss
+++ b/core/scss/components/_components.header.scss
@@ -31,9 +31,9 @@
     bottom: 0;
     box-shadow: 0 0 4px 0 fade-out($color-body, .75);
     content: '';
-    display: fixed;
     height: 4em;
     left: 0;
+    position: fixed;
     width: 100%;
     z-index: 1;
   }

--- a/core/scss/elements/_elements.body.scss
+++ b/core/scss/elements/_elements.body.scss
@@ -7,4 +7,5 @@ body {
   color: $color-body;
   background-color: $color-body-bg;
   margin: 0;
+  overflow-x: hidden;
 }

--- a/core/scss/elements/_elements.main.scss
+++ b/core/scss/elements/_elements.main.scss
@@ -4,6 +4,7 @@
 
 
 main {
+  display: block; // This fixes the display in Internet Explorer
 
   &:focus {
     outline: none; // !temp

--- a/core/scss/elements/_elements.main.scss
+++ b/core/scss/elements/_elements.main.scss
@@ -5,9 +5,4 @@
 
 main {
   display: block; // This fixes the display in Internet Explorer
-
-  &:focus {
-    outline: none; // !temp
-  }
-
 }

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -328,8 +328,6 @@ dd + dt {
 
 main {
   display: block; }
-  main:focus {
-    outline: none; }
 
 mark {
   background-color: #ff0;

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -103,7 +103,8 @@ blockquote {
 body {
   color: #444;
   background-color: #fff;
-  margin: 0; }
+  margin: 0;
+  overflow-x: hidden; }
 
 button,
 input[type="button"],

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -1086,9 +1086,9 @@ a.dcf-c-calendar__date--active:focus {
     -webkit-box-shadow: 0 0 4px 0 rgba(68, 68, 68, 0.25);
             box-shadow: 0 0 4px 0 rgba(68, 68, 68, 0.25);
     content: '';
-    display: fixed;
     height: 4em;
     left: 0;
+    position: fixed;
     width: 100%;
     z-index: 1; } }
 

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -326,8 +326,10 @@ dd {
 dd + dt {
   margin-top: 1em; }
 
-main:focus {
-  outline: none; }
+main {
+  display: block; }
+  main:focus {
+    outline: none; }
 
 mark {
   background-color: #ff0;

--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -1777,7 +1777,7 @@
   -->
 
       <h3 class="dcf-u-mt8" id="example-components-pagination">Pagination</h3>
-      <p>See <a href="example-objects-inline-lists">Inline Lists</a></p>
+      <p>See <a href="#example-objects-inline-lists">Inline Lists</a></p>
 
 <!--
       <h3 class="dcf-u-mt8" id="example-components-paragraphs">Paragraphs</h3>


### PR DESCRIPTION
- Fix link from Pagination section to Inline Lists in documentation
- Header position—not display—fixed
- <main> element display: block fix for IE
- Remove temporary focus outline: none
- Add overflow-x hidden to body to prevent horizontal scrollbar from appearing due to use of viewport units for full-width/“stretch” object