### PR TITLE
Documentation: object-fit, lazy-load, breakpoints, modular scale

### DIFF
--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -2385,6 +2385,20 @@
         <dt><code>.dcf-obj-fit-cover</code></dt><dd>object-fit: cover</dd>
       </dl>
 
+      <figure class="dcf-mt-6">
+        <div class="dcf-ratio dcf-ratio-4x3 dcf-w-10 dcf-b-1">
+          <img class="dcf-ratio-child dcf-obj-fit-contain" src="http://via.placeholder.com/400x400" width="400" height="400" alt="">
+        </div>
+        <figcaption class="dcf-figcaption dcf-mt-4">Demonstration of object-fit contain</figcaption>
+      </figure>
+
+      <figure class="dcf-mt-6">
+        <div class="dcf-ratio dcf-ratio-4x3 dcf-w-10 dcf-b-1">
+          <img class="dcf-ratio-child dcf-obj-fit-cover" src="http://via.placeholder.com/400x400" width="400" height="400" alt="">
+        </div>
+        <figcaption class="dcf-figcaption dcf-mt-4">Demonstration of object-fit cover</figcaption>
+      </figure>
+
       <h3 class="dcf-mt-8" id="example-utilities-order">Order (for Flexbox and Grid)</h3>
       <dl>
         <dt><code>.dcf-1st</code></dt><dd>first</dd>

--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -92,12 +92,270 @@
     <p class="dcf-mt-6"><a href="#example-elements">Element</a> styles are applied directly to an element, while <a href="#example-objects">object</a>, <a href="#example-components">component</a> and <a href="#example-utilities">utility</a> styles are applied by adding classes to the elements in the markup. These classes are prefixed with the <code>dcf-</code> namespace to avoid code collisions with third-party or custom styles. Please prefix your own custom styles with a namespace unique to your organization.</p>
 
     <ul class="dcf-mt-6">
+      <li><a href="#example-general">General</a></li>
       <li><a href="#example-elements">Elements</a></li>
       <li><a href="#example-objects">Objects</a></li>
       <li><a href="#example-components">Components</a></li>
       <li><a href="#example-utilities">Utilities</a></li>
       <li><a href="#example-javascript">JavaScript</a></li>
     </ul>
+
+    <!-- !General -->
+    <section class="dcf-pt-10 dcf-mb-10" id="example-general">
+      <h2>General</h2>
+      <p></p>
+      <ul class="dcf-mt-6">
+        <li><a href="#example-general-breakpoints">Breakpoints</a></li>
+        <li><a href="#example-general-modular-scale">Modular Scale</a></li>
+      </ul>
+
+      <h3 class="dcf-mt-8" id="example-general-breakpoints">Breakpoints</h3>
+      <p>It’s foolish to define breakpoints that attempt to target the resolutions of popular devices and screen sizes. Those resolutions are constantly changing as manufacturers compete to pack more pixels into screens. Screen size matters little on desktop as a user can resize a browser window to a seemingly infinite combination of heights and widths. Instead, this framework’s device-agnostic breakpoints map to values in its <a href="#example-general-modular-scale">modular scale</a>.</p>
+      <table class="dcf-mt-6 dcf-table">
+        <caption>The framework’s breakpoints are shown with their corresponding em and pixel values rounded to two decimal points.</caption>
+        <thead>
+          <tr>
+            <th>Breakpoint</th>
+            <th class="dcf-txt-right">Em Value</th>
+            <th class="dcf-txt-right">Pixel Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>sm</td>
+            <td class="dcf-txt-right">41.96</td>
+            <td class="dcf-txt-right">671.3</td>
+          </tr>
+          <tr>
+            <td>md</td>
+            <td class="dcf-txt-right">55.93</td>
+            <td class="dcf-txt-right">894.8</td>
+          </tr>
+          <tr>
+            <td>lg</td>
+            <td class="dcf-txt-right">74.55</td>
+            <td class="dcf-txt-right">1192.8</td>
+          </tr>
+          <tr>
+            <td>xl</td>
+            <td class="dcf-txt-right">99.38</td>
+            <td class="dcf-txt-right">1590</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h3 class="dcf-mt-8" id="example-general-modular-scale">Modular Scale</h3>
+      <p>Rather than eyeball it and choose arbitrary numbers for things like font-size, padding and margin, the framework utilizes a <a href="https://alistapart.com/article/more-meaningful-typography">modular scale</a>, resulting in a more visually consistent and harmonious composition. The scale consists of a primary and secondary strand of values that are calculated with the perfect fourth (1.333) ratio. These proportions align well with common media formats—16:9 and 4:3.</p>
+
+      <table class="dcf-mt-6 dcf-table">
+        <caption>The framework modular scale is shown in em and pixel values rounded to two decimal points. The primary strand values are shown in bold.</caption>
+        <thead>
+          <tr>
+            <th class="dcf-txt-right">Em Value</th>
+            <th class="dcf-txt-right">Pixel Value</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">.18</td>
+            <td class="dcf-txt-right dcf-bold">2.85</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">.2</td>
+            <td class="dcf-txt-right">3.2</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">.24</td>
+            <td class="dcf-txt-right dcf-bold">3.8</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">.27</td>
+            <td class="dcf-txt-right">4.27</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">.32</td>
+            <td class="dcf-txt-right dcf-bold">5.07</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">.36</td>
+            <td class="dcf-txt-right">5.7</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">.42</td>
+            <td class="dcf-txt-right dcf-bold">6.75</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">.47</td>
+            <td class="dcf-txt-right">7.6</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">.56</td>
+            <td class="dcf-txt-right dcf-bold">9</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">.63</td>
+            <td class="dcf-txt-right">10.13</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">.75</td>
+            <td class="dcf-txt-right dcf-bold">12</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">.84</td>
+            <td class="dcf-txt-right">13.5</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">1</td>
+            <td class="dcf-txt-right dcf-bold">16</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">1.13</td>
+            <td class="dcf-txt-right">18</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">1.33</td>
+            <td class="dcf-txt-right dcf-bold">21.33</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">1.5</td>
+            <td class="dcf-txt-right">24</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">1.77</td>
+            <td class="dcf-txt-right dcf-bold">28.45</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">2</td>
+            <td class="dcf-txt-right">32</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">2.37</td>
+            <td class="dcf-txt-right dcf-bold">37.9</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">2.67</td>
+            <td class="dcf-txt-right">42.67</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">3.16</td>
+            <td class="dcf-txt-right dcf-bold">50.51</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">3.56</td>
+            <td class="dcf-txt-right">56.88</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">4.21</td>
+            <td class="dcf-txt-right dcf-bold">67.34</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">4.74</td>
+            <td class="dcf-txt-right">75.85</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">5.62</td>
+            <td class="dcf-txt-right dcf-bold">89.9</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">6.32</td>
+            <td class="dcf-txt-right">101.13</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">7.49</td>
+            <td class="dcf-txt-right dcf-bold">119.87</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">8.43</td>
+            <td class="dcf-txt-right">134.85</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">9.99</td>
+            <td class="dcf-txt-right dcf-bold">159.82</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">11.24</td>
+            <td class="dcf-txt-right">179.8</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">13.32</td>
+            <td class="dcf-txt-right dcf-bold">213.1</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">14.98</td>
+            <td class="dcf-txt-right">293.73</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">17.76</td>
+            <td class="dcf-txt-right dcf-bold">284.12</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">19.98</td>
+            <td class="dcf-txt-right">319.63</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">23.68</td>
+            <td class="dcf-txt-right dcf-bold">378.83</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">26.64</td>
+            <td class="dcf-txt-right">426.18</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">31.57</td>
+            <td class="dcf-txt-right dcf-bold">505.12</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">35.52</td>
+            <td class="dcf-txt-right">568.25</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">42.09</td>
+            <td class="dcf-txt-right dcf-bold">673.48</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">47.35</td>
+            <td class="dcf-txt-right">757.67</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">56.12</td>
+            <td class="dcf-txt-right dcf-bold">897.97</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">63.14</td>
+            <td class="dcf-txt-right">1010.22</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">74.83</td>
+            <td class="dcf-txt-right dcf-bold">1197.3</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">84.18</td>
+            <td class="dcf-txt-right">1346.95</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">99.78</td>
+            <td class="dcf-txt-right dcf-bold">1596.4</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">112.25</td>
+            <td class="dcf-txt-right">1795.95</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">133.03</td>
+            <td class="dcf-txt-right dcf-bold">2128.52</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right">149.66</td>
+            <td class="dcf-txt-right">2394.58</td>
+          </tr>
+          <tr>
+            <td class="dcf-txt-right dcf-bold">177.38</td>
+            <td class="dcf-txt-right dcf-bold">2838.03</td>
+          </tr>
+        </tbody>
+      </table>
+
+    </section>
 
     <!-- !Elements -->
     <section class="dcf-pt-10 dcf-mb-10" id="example-elements">

--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -2653,6 +2653,7 @@
         <noscript>
           <img src="http://via.placeholder.com/400x300" width="400" height="300" alt="blank placeholder image for lazy-loading demonstration">
         </noscript>
+        <figcaption class="dcf-figcaption dcf-mt-4">Demonstration of lazy-loading and animating an image.</figcaption>
       </figure>
       <p class="dcf-mt-6 dcf-pl-4 dcf-bl"><b>Related:</b> <a href="#example-elements-images">Images</a> (Elements)</p>
 


### PR DESCRIPTION
- Add "General" section to documentation
- Document breakpoints (closes #113)
- Document modular scale (closes #114)
- Add object-fit demonstrations
- Add `figcaption` to lazy-load demo