### PR TITLE
Rename grid column classes

### DIFF
--- a/core/scss/objects/_objects.grids.scss
+++ b/core/scss/objects/_objects.grids.scss
@@ -48,43 +48,43 @@
   flex-basis: 100%;
 }
 
-.dcf-grid-col-50\%-l {
+.dcf-col-50\%-start {
   flex-basis: 50%;
 }
 
-.dcf-grid-col-50\%-r {
+.dcf-col-50\%-end {
   flex-basis: 50%;
 }
 
-.dcf-grid-col-33\%-l {
+.dcf-col-33\%-start {
   flex-basis: 33%;
 }
 
-.dcf-grid-col-33\%-r {
+.dcf-col-33\%-end {
   flex-basis: 33%;
 }
 
-.dcf-grid-col-67\%-l {
+.dcf-col-67\%-start {
   flex-basis: 67%;
 }
 
-.dcf-grid-col-67\%-r {
+.dcf-col-67\%-end {
   flex-basis: 67%;
 }
 
-.dcf-grid-col-25\%-l {
+.dcf-col-25\%-start {
   flex-basis: 25%;
 }
 
-.dcf-grid-col-25\%-r {
+.dcf-col-25\%-end {
   flex-basis: 25%;
 }
 
-.dcf-grid-col-75\%-l {
+.dcf-col-75\%-start {
   flex-basis: 75%;
 }
 
-.dcf-grid-col-75\%-r {
+.dcf-col-75\%-end {
   flex-basis: 75%;
 }
 
@@ -103,43 +103,43 @@
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-50\%-l\@sm {
+  .dcf-col-50\%-start\@sm {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-50\%-r\@sm {
+  .dcf-col-50\%-end\@sm {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-33\%-l\@sm {
+  .dcf-col-33\%-start\@sm {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-33\%-r\@sm {
+  .dcf-col-33\%-end\@sm {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-67\%-l\@sm {
+  .dcf-col-67\%-start\@sm {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-67\%-r\@sm {
+  .dcf-col-67\%-end\@sm {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-25\%-l\@sm {
+  .dcf-col-25\%-start\@sm {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-25\%-r\@sm {
+  .dcf-col-25\%-end\@sm {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-75\%-l\@sm {
+  .dcf-col-75\%-start\@sm {
     flex-basis: 75%;
   }
 
-  .dcf-grid-col-75\%-r\@sm {
+  .dcf-col-75\%-end\@sm {
     flex-basis: 75%;
   }
 
@@ -168,43 +168,43 @@
     flex-basis: 16.66%;
   }
 
-  .dcf-grid-col-50\%-l\@md {
+  .dcf-col-50\%-start\@md {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-50\%-r\@md {
+  .dcf-col-50\%-end\@md {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-33\%-l\@md {
+  .dcf-col-33\%-start\@md {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-33\%-r\@md {
+  .dcf-col-33\%-end\@md {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-67\%-l\@md {
+  .dcf-col-67\%-start\@md {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-67\%-r\@md {
+  .dcf-col-67\%-end\@md {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-25\%-l\@md {
+  .dcf-col-25\%-start\@md {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-25\%-r\@md {
+  .dcf-col-25\%-end\@md {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-75\%-l\@md {
+  .dcf-col-75\%-start\@md {
     flex-basis: 75%;
   }
 
-  .dcf-grid-col-75\%-r\@md {
+  .dcf-col-75\%-end\@md {
     flex-basis: 75%;
   }
 
@@ -233,43 +233,43 @@
     flex-basis: 16.66%;
   }
 
-  .dcf-grid-col-50\%-l\@lg {
+  .dcf-col-50\%-start\@lg {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-50\%-r\@lg {
+  .dcf-col-50\%-end\@lg {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-33\%-l\@lg {
+  .dcf-col-33\%-start\@lg {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-33\%-r\@lg {
+  .dcf-col-33\%-end\@lg {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-67\%-l\@lg {
+  .dcf-col-67\%-start\@lg {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-67\%-r\@lg {
+  .dcf-col-67\%-end\@lg {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-25\%-l\@lg {
+  .dcf-col-25\%-start\@lg {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-25\%-r\@lg {
+  .dcf-col-25\%-end\@lg {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-75\%-l\@lg {
+  .dcf-col-75\%-start\@lg {
     flex-basis: 75%;
   }
 
-  .dcf-grid-col-75\%-r\@lg {
+  .dcf-col-75\%-end\@lg {
     flex-basis: 75%;
   }
 
@@ -298,43 +298,43 @@
     flex-basis: 16.66%;
   }
 
-  .dcf-grid-col-50\%-l\@xl {
+  .dcf-col-50\%-start\@xl {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-50\%-r\@xl {
+  .dcf-col-50\%-end\@xl {
     flex-basis: 50%;
   }
 
-  .dcf-grid-col-33\%-l\@xl {
+  .dcf-col-33\%-start\@xl {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-33\%-r\@xl {
+  .dcf-col-33\%-end\@xl {
     flex-basis: 33%;
   }
 
-  .dcf-grid-col-67\%-l\@xl {
+  .dcf-col-67\%-start\@xl {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-67\%-r\@xl {
+  .dcf-col-67\%-end\@xl {
     flex-basis: 67%;
   }
 
-  .dcf-grid-col-25\%-l\@xl {
+  .dcf-col-25\%-start\@xl {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-25\%-r\@xl {
+  .dcf-col-25\%-end\@xl {
     flex-basis: 25%;
   }
 
-  .dcf-grid-col-75\%-l\@xl {
+  .dcf-col-75\%-start\@xl {
     flex-basis: 75%;
   }
 
-  .dcf-grid-col-75\%-r\@xl {
+  .dcf-col-75\%-end\@xl {
     flex-basis: 75%;
   }
 
@@ -390,43 +390,43 @@
     grid-column: 1 / span 12;
   }
 
-  .dcf-grid-col-50\%-l {
+  .dcf-col-50\%-start {
     grid-column: 1 / span 6;
   }
 
-  .dcf-grid-col-50\%-r {
+  .dcf-col-50\%-end {
     grid-column: span 6 / -1;
   }
 
-  .dcf-grid-col-33\%-l {
+  .dcf-col-33\%-start {
     grid-column: 1 / span 4;
   }
 
-  .dcf-grid-col-33\%-r {
+  .dcf-col-33\%-end {
     grid-column: span 4 / -1;
   }
 
-  .dcf-grid-col-67\%-l {
+  .dcf-col-67\%-start {
     grid-column: 1 / span 8;
   }
 
-  .dcf-grid-col-67\%-r {
+  .dcf-col-67\%-end {
     grid-column: span 8 / -1;
   }
 
-  .dcf-grid-col-25\%-l {
+  .dcf-col-25\%-start {
     grid-column: 1 / span 3;
   }
 
-  .dcf-grid-col-25\%-r {
+  .dcf-col-25\%-end {
     grid-column: span 3 / -1;
   }
 
-  .dcf-grid-col-75\%-l {
+  .dcf-col-75\%-start {
     grid-column: 1 / span 9;
   }
 
-  .dcf-grid-col-75\%-r {
+  .dcf-col-75\%-end {
     grid-column: span 9 / -1;
   }
 
@@ -445,43 +445,43 @@
       grid-template-columns: repeat(4, 1fr);
     }
 
-    .dcf-grid-col-50\%-l\@sm {
+    .dcf-col-50\%-start\@sm {
       grid-column: 1 / span 6;
     }
 
-    .dcf-grid-col-50\%-r\@sm {
+    .dcf-col-50\%-end\@sm {
       grid-column: span 6 / -1;
     }
 
-    .dcf-grid-col-33\%-l\@sm {
+    .dcf-col-33\%-start\@sm {
       grid-column: 1 / span 4;
     }
 
-    .dcf-grid-col-33\%-r\@sm {
+    .dcf-col-33\%-end\@sm {
       grid-column: span 4 / -1;
     }
 
-    .dcf-grid-col-67\%-l\@sm {
+    .dcf-col-67\%-start\@sm {
       grid-column: 1 / span 8;
     }
 
-    .dcf-grid-col-67\%-r\@sm {
+    .dcf-col-67\%-end\@sm {
       grid-column: span 8 / -1;
     }
 
-    .dcf-grid-col-25\%-l\@sm {
+    .dcf-col-25\%-start\@sm {
       grid-column: 1 / span 3;
     }
 
-    .dcf-grid-col-25\%-r\@sm {
+    .dcf-col-25\%-end\@sm {
       grid-column: span 3 / -1;
     }
 
-    .dcf-grid-col-75\%-l\@sm {
+    .dcf-col-75\%-start\@sm {
       grid-column: 1 / span 9;
     }
 
-    .dcf-grid-col-75\%-r\@sm {
+    .dcf-col-75\%-end\@sm {
       grid-column: span 9 / -1;
     }
 
@@ -510,43 +510,43 @@
       grid-template-columns: repeat(6, 1fr);
     }
 
-    .dcf-grid-col-50\%-l\@md {
+    .dcf-col-50\%-start\@md {
       grid-column: 1 / span 6;
     }
 
-    .dcf-grid-col-50\%-r\@md {
+    .dcf-col-50\%-end\@md {
       grid-column: span 6 / -1;
     }
 
-    .dcf-grid-col-33\%-l\@md {
+    .dcf-col-33\%-start\@md {
       grid-column: 1 / span 4;
     }
 
-    .dcf-grid-col-33\%-r\@md {
+    .dcf-col-33\%-end\@md {
       grid-column: span 4 / -1;
     }
 
-    .dcf-grid-col-67\%-l\@md {
+    .dcf-col-67\%-start\@md {
       grid-column: 1 / span 8;
     }
 
-    .dcf-grid-col-67\%-r\@md {
+    .dcf-col-67\%-end\@md {
       grid-column: span 8 / -1;
     }
 
-    .dcf-grid-col-25\%-l\@md {
+    .dcf-col-25\%-start\@md {
       grid-column: 1 / span 3;
     }
 
-    .dcf-grid-col-25\%-r\@md {
+    .dcf-col-25\%-end\@md {
       grid-column: span 3 / -1;
     }
 
-    .dcf-grid-col-75\%-l\@md {
+    .dcf-col-75\%-start\@md {
       grid-column: 1 / span 9;
     }
 
-    .dcf-grid-col-75\%-r\@md {
+    .dcf-col-75\%-end\@md {
       grid-column: span 9 / -1;
     }
 
@@ -575,43 +575,43 @@
       grid-template-columns: repeat(6, 1fr);
     }
 
-    .dcf-grid-col-50\%-l\@lg {
+    .dcf-col-50\%-start\@lg {
       grid-column: 1 / span 6;
     }
 
-    .dcf-grid-col-50\%-r\@lg {
+    .dcf-col-50\%-end\@lg {
       grid-column: span 6 / -1;
     }
 
-    .dcf-grid-col-33\%-l\@lg {
+    .dcf-col-33\%-start\@lg {
       grid-column: 1 / span 4;
     }
 
-    .dcf-grid-col-33\%-r\@lg {
+    .dcf-col-33\%-end\@lg {
       grid-column: span 4 / -1;
     }
 
-    .dcf-grid-col-67\%-l\@lg {
+    .dcf-col-67\%-start\@lg {
       grid-column: 1 / span 8;
     }
 
-    .dcf-grid-col-67\%-r\@lg {
+    .dcf-col-67\%-end\@lg {
       grid-column: span 8 / -1;
     }
 
-    .dcf-grid-col-25\%-l\@lg {
+    .dcf-col-25\%-start\@lg {
       grid-column: 1 / span 3;
     }
 
-    .dcf-grid-col-25\%-r\@lg {
+    .dcf-col-25\%-end\@lg {
       grid-column: span 3 / -1;
     }
 
-    .dcf-grid-col-75\%-l\@lg {
+    .dcf-col-75\%-start\@lg {
       grid-column: 1 / span 9;
     }
 
-    .dcf-grid-col-75\%-r\@lg {
+    .dcf-col-75\%-end\@lg {
       grid-column: span 9 / -1;
     }
 
@@ -640,43 +640,43 @@
       grid-template-columns: repeat(6, 1fr);
     }
 
-    .dcf-grid-col-50\%-l\@xl {
+    .dcf-col-50\%-start\@xl {
       grid-column: 1 / span 6;
     }
 
-    .dcf-grid-col-50\%-r\@xl {
+    .dcf-col-50\%-end\@xl {
       grid-column: span 6 / -1;
     }
 
-    .dcf-grid-col-33\%-l\@xl {
+    .dcf-col-33\%-start\@xl {
       grid-column: 1 / span 4;
     }
 
-    .dcf-grid-col-33\%-r\@xl {
+    .dcf-col-33\%-end\@xl {
       grid-column: span 4 / -1;
     }
 
-    .dcf-grid-col-67\%-l\@xl {
+    .dcf-col-67\%-start\@xl {
       grid-column: 1 / span 8;
     }
 
-    .dcf-grid-col-67\%-r\@xl {
+    .dcf-col-67\%-end\@xl {
       grid-column: span 8 / -1;
     }
 
-    .dcf-grid-col-25\%-l\@xl {
+    .dcf-col-25\%-start\@xl {
       grid-column: 1 / span 3;
     }
 
-    .dcf-grid-col-25\%-r\@xl {
+    .dcf-col-25\%-end\@xl {
       grid-column: span 3 / -1;
     }
 
-    .dcf-grid-col-75\%-l\@xl {
+    .dcf-col-75\%-start\@xl {
       grid-column: 1 / span 9;
     }
 
-    .dcf-grid-col-75\%-r\@xl {
+    .dcf-col-75\%-end\@xl {
       grid-column: span 9 / -1;
     }
 

--- a/theme/example/css/all.css
+++ b/theme/example/css/all.css
@@ -422,34 +422,34 @@ th {
 [class*='dcf-grid-col'] {
   flex-basis: 100%; }
 
-.dcf-grid-col-50\%-l {
+.dcf-col-50\%-start {
   flex-basis: 50%; }
 
-.dcf-grid-col-50\%-r {
+.dcf-col-50\%-end {
   flex-basis: 50%; }
 
-.dcf-grid-col-33\%-l {
+.dcf-col-33\%-start {
   flex-basis: 33%; }
 
-.dcf-grid-col-33\%-r {
+.dcf-col-33\%-end {
   flex-basis: 33%; }
 
-.dcf-grid-col-67\%-l {
+.dcf-col-67\%-start {
   flex-basis: 67%; }
 
-.dcf-grid-col-67\%-r {
+.dcf-col-67\%-end {
   flex-basis: 67%; }
 
-.dcf-grid-col-25\%-l {
+.dcf-col-25\%-start {
   flex-basis: 25%; }
 
-.dcf-grid-col-25\%-r {
+.dcf-col-25\%-end {
   flex-basis: 25%; }
 
-.dcf-grid-col-75\%-l {
+.dcf-col-75\%-start {
   flex-basis: 75%; }
 
-.dcf-grid-col-75\%-r {
+.dcf-col-75\%-end {
   flex-basis: 75%; }
 
 @media only screen and (min-width: 41.95625em) {
@@ -459,25 +459,25 @@ th {
     flex-basis: 33%; }
   .dcf-grid-fourths\@sm > * {
     flex-basis: 25%; }
-  .dcf-grid-col-50\%-l\@sm {
+  .dcf-col-50\%-start\@sm {
     flex-basis: 50%; }
-  .dcf-grid-col-50\%-r\@sm {
+  .dcf-col-50\%-end\@sm {
     flex-basis: 50%; }
-  .dcf-grid-col-33\%-l\@sm {
+  .dcf-col-33\%-start\@sm {
     flex-basis: 33%; }
-  .dcf-grid-col-33\%-r\@sm {
+  .dcf-col-33\%-end\@sm {
     flex-basis: 33%; }
-  .dcf-grid-col-67\%-l\@sm {
+  .dcf-col-67\%-start\@sm {
     flex-basis: 67%; }
-  .dcf-grid-col-67\%-r\@sm {
+  .dcf-col-67\%-end\@sm {
     flex-basis: 67%; }
-  .dcf-grid-col-25\%-l\@sm {
+  .dcf-col-25\%-start\@sm {
     flex-basis: 25%; }
-  .dcf-grid-col-25\%-r\@sm {
+  .dcf-col-25\%-end\@sm {
     flex-basis: 25%; }
-  .dcf-grid-col-75\%-l\@sm {
+  .dcf-col-75\%-start\@sm {
     flex-basis: 75%; }
-  .dcf-grid-col-75\%-r\@sm {
+  .dcf-col-75\%-end\@sm {
     flex-basis: 75%; } }
 
 @media only screen and (min-width: 55.925em) {
@@ -491,25 +491,25 @@ th {
     flex-basis: 20%; }
   .dcf-grid-sixths\@md > * {
     flex-basis: 16.66%; }
-  .dcf-grid-col-50\%-l\@md {
+  .dcf-col-50\%-start\@md {
     flex-basis: 50%; }
-  .dcf-grid-col-50\%-r\@md {
+  .dcf-col-50\%-end\@md {
     flex-basis: 50%; }
-  .dcf-grid-col-33\%-l\@md {
+  .dcf-col-33\%-start\@md {
     flex-basis: 33%; }
-  .dcf-grid-col-33\%-r\@md {
+  .dcf-col-33\%-end\@md {
     flex-basis: 33%; }
-  .dcf-grid-col-67\%-l\@md {
+  .dcf-col-67\%-start\@md {
     flex-basis: 67%; }
-  .dcf-grid-col-67\%-r\@md {
+  .dcf-col-67\%-end\@md {
     flex-basis: 67%; }
-  .dcf-grid-col-25\%-l\@md {
+  .dcf-col-25\%-start\@md {
     flex-basis: 25%; }
-  .dcf-grid-col-25\%-r\@md {
+  .dcf-col-25\%-end\@md {
     flex-basis: 25%; }
-  .dcf-grid-col-75\%-l\@md {
+  .dcf-col-75\%-start\@md {
     flex-basis: 75%; }
-  .dcf-grid-col-75\%-r\@md {
+  .dcf-col-75\%-end\@md {
     flex-basis: 75%; } }
 
 @media only screen and (min-width: 74.55em) {
@@ -523,25 +523,25 @@ th {
     flex-basis: 20%; }
   .dcf-grid-sixths\@lg > * {
     flex-basis: 16.66%; }
-  .dcf-grid-col-50\%-l\@lg {
+  .dcf-col-50\%-start\@lg {
     flex-basis: 50%; }
-  .dcf-grid-col-50\%-r\@lg {
+  .dcf-col-50\%-end\@lg {
     flex-basis: 50%; }
-  .dcf-grid-col-33\%-l\@lg {
+  .dcf-col-33\%-start\@lg {
     flex-basis: 33%; }
-  .dcf-grid-col-33\%-r\@lg {
+  .dcf-col-33\%-end\@lg {
     flex-basis: 33%; }
-  .dcf-grid-col-67\%-l\@lg {
+  .dcf-col-67\%-start\@lg {
     flex-basis: 67%; }
-  .dcf-grid-col-67\%-r\@lg {
+  .dcf-col-67\%-end\@lg {
     flex-basis: 67%; }
-  .dcf-grid-col-25\%-l\@lg {
+  .dcf-col-25\%-start\@lg {
     flex-basis: 25%; }
-  .dcf-grid-col-25\%-r\@lg {
+  .dcf-col-25\%-end\@lg {
     flex-basis: 25%; }
-  .dcf-grid-col-75\%-l\@lg {
+  .dcf-col-75\%-start\@lg {
     flex-basis: 75%; }
-  .dcf-grid-col-75\%-r\@lg {
+  .dcf-col-75\%-end\@lg {
     flex-basis: 75%; } }
 
 @media only screen and (min-width: 99.375em) {
@@ -555,25 +555,25 @@ th {
     flex-basis: 20%; }
   .dcf-grid-sixths\@xl > * {
     flex-basis: 16.66%; }
-  .dcf-grid-col-50\%-l\@xl {
+  .dcf-col-50\%-start\@xl {
     flex-basis: 50%; }
-  .dcf-grid-col-50\%-r\@xl {
+  .dcf-col-50\%-end\@xl {
     flex-basis: 50%; }
-  .dcf-grid-col-33\%-l\@xl {
+  .dcf-col-33\%-start\@xl {
     flex-basis: 33%; }
-  .dcf-grid-col-33\%-r\@xl {
+  .dcf-col-33\%-end\@xl {
     flex-basis: 33%; }
-  .dcf-grid-col-67\%-l\@xl {
+  .dcf-col-67\%-start\@xl {
     flex-basis: 67%; }
-  .dcf-grid-col-67\%-r\@xl {
+  .dcf-col-67\%-end\@xl {
     flex-basis: 67%; }
-  .dcf-grid-col-25\%-l\@xl {
+  .dcf-col-25\%-start\@xl {
     flex-basis: 25%; }
-  .dcf-grid-col-25\%-r\@xl {
+  .dcf-col-25\%-end\@xl {
     flex-basis: 25%; }
-  .dcf-grid-col-75\%-l\@xl {
+  .dcf-col-75\%-start\@xl {
     flex-basis: 75%; }
-  .dcf-grid-col-75\%-r\@xl {
+  .dcf-col-75\%-end\@xl {
     flex-basis: 75%; } }
 
 @supports (display: grid) {
@@ -610,25 +610,25 @@ th {
     grid-template-columns: repeat(4, 1fr); }
   [class*='dcf-grid-col'] {
     grid-column: 1 / span 12; }
-  .dcf-grid-col-50\%-l {
+  .dcf-col-50\%-start {
     grid-column: 1 / span 6; }
-  .dcf-grid-col-50\%-r {
+  .dcf-col-50\%-end {
     grid-column: span 6 / -1; }
-  .dcf-grid-col-33\%-l {
+  .dcf-col-33\%-start {
     grid-column: 1 / span 4; }
-  .dcf-grid-col-33\%-r {
+  .dcf-col-33\%-end {
     grid-column: span 4 / -1; }
-  .dcf-grid-col-67\%-l {
+  .dcf-col-67\%-start {
     grid-column: 1 / span 8; }
-  .dcf-grid-col-67\%-r {
+  .dcf-col-67\%-end {
     grid-column: span 8 / -1; }
-  .dcf-grid-col-25\%-l {
+  .dcf-col-25\%-start {
     grid-column: 1 / span 3; }
-  .dcf-grid-col-25\%-r {
+  .dcf-col-25\%-end {
     grid-column: span 3 / -1; }
-  .dcf-grid-col-75\%-l {
+  .dcf-col-75\%-start {
     grid-column: 1 / span 9; }
-  .dcf-grid-col-75\%-r {
+  .dcf-col-75\%-end {
     grid-column: span 9 / -1; }
   @media only screen and (min-width: 41.95625em) {
     .dcf-grid-halves\@sm {
@@ -637,25 +637,25 @@ th {
       grid-template-columns: repeat(3, 1fr); }
     .dcf-grid-fourths\@sm {
       grid-template-columns: repeat(4, 1fr); }
-    .dcf-grid-col-50\%-l\@sm {
+    .dcf-col-50\%-start\@sm {
       grid-column: 1 / span 6; }
-    .dcf-grid-col-50\%-r\@sm {
+    .dcf-col-50\%-end\@sm {
       grid-column: span 6 / -1; }
-    .dcf-grid-col-33\%-l\@sm {
+    .dcf-col-33\%-start\@sm {
       grid-column: 1 / span 4; }
-    .dcf-grid-col-33\%-r\@sm {
+    .dcf-col-33\%-end\@sm {
       grid-column: span 4 / -1; }
-    .dcf-grid-col-67\%-l\@sm {
+    .dcf-col-67\%-start\@sm {
       grid-column: 1 / span 8; }
-    .dcf-grid-col-67\%-r\@sm {
+    .dcf-col-67\%-end\@sm {
       grid-column: span 8 / -1; }
-    .dcf-grid-col-25\%-l\@sm {
+    .dcf-col-25\%-start\@sm {
       grid-column: 1 / span 3; }
-    .dcf-grid-col-25\%-r\@sm {
+    .dcf-col-25\%-end\@sm {
       grid-column: span 3 / -1; }
-    .dcf-grid-col-75\%-l\@sm {
+    .dcf-col-75\%-start\@sm {
       grid-column: 1 / span 9; }
-    .dcf-grid-col-75\%-r\@sm {
+    .dcf-col-75\%-end\@sm {
       grid-column: span 9 / -1; } }
   @media only screen and (min-width: 55.925em) {
     .dcf-grid-halves\@md {
@@ -668,25 +668,25 @@ th {
       grid-template-columns: repeat(5, 1fr); }
     .dcf-grid-sixths\@md {
       grid-template-columns: repeat(6, 1fr); }
-    .dcf-grid-col-50\%-l\@md {
+    .dcf-col-50\%-start\@md {
       grid-column: 1 / span 6; }
-    .dcf-grid-col-50\%-r\@md {
+    .dcf-col-50\%-end\@md {
       grid-column: span 6 / -1; }
-    .dcf-grid-col-33\%-l\@md {
+    .dcf-col-33\%-start\@md {
       grid-column: 1 / span 4; }
-    .dcf-grid-col-33\%-r\@md {
+    .dcf-col-33\%-end\@md {
       grid-column: span 4 / -1; }
-    .dcf-grid-col-67\%-l\@md {
+    .dcf-col-67\%-start\@md {
       grid-column: 1 / span 8; }
-    .dcf-grid-col-67\%-r\@md {
+    .dcf-col-67\%-end\@md {
       grid-column: span 8 / -1; }
-    .dcf-grid-col-25\%-l\@md {
+    .dcf-col-25\%-start\@md {
       grid-column: 1 / span 3; }
-    .dcf-grid-col-25\%-r\@md {
+    .dcf-col-25\%-end\@md {
       grid-column: span 3 / -1; }
-    .dcf-grid-col-75\%-l\@md {
+    .dcf-col-75\%-start\@md {
       grid-column: 1 / span 9; }
-    .dcf-grid-col-75\%-r\@md {
+    .dcf-col-75\%-end\@md {
       grid-column: span 9 / -1; } }
   @media only screen and (min-width: 74.55em) {
     .dcf-grid-halves\@lg {
@@ -699,25 +699,25 @@ th {
       grid-template-columns: repeat(5, 1fr); }
     .dcf-grid-sixths\@lg {
       grid-template-columns: repeat(6, 1fr); }
-    .dcf-grid-col-50\%-l\@lg {
+    .dcf-col-50\%-start\@lg {
       grid-column: 1 / span 6; }
-    .dcf-grid-col-50\%-r\@lg {
+    .dcf-col-50\%-end\@lg {
       grid-column: span 6 / -1; }
-    .dcf-grid-col-33\%-l\@lg {
+    .dcf-col-33\%-start\@lg {
       grid-column: 1 / span 4; }
-    .dcf-grid-col-33\%-r\@lg {
+    .dcf-col-33\%-end\@lg {
       grid-column: span 4 / -1; }
-    .dcf-grid-col-67\%-l\@lg {
+    .dcf-col-67\%-start\@lg {
       grid-column: 1 / span 8; }
-    .dcf-grid-col-67\%-r\@lg {
+    .dcf-col-67\%-end\@lg {
       grid-column: span 8 / -1; }
-    .dcf-grid-col-25\%-l\@lg {
+    .dcf-col-25\%-start\@lg {
       grid-column: 1 / span 3; }
-    .dcf-grid-col-25\%-r\@lg {
+    .dcf-col-25\%-end\@lg {
       grid-column: span 3 / -1; }
-    .dcf-grid-col-75\%-l\@lg {
+    .dcf-col-75\%-start\@lg {
       grid-column: 1 / span 9; }
-    .dcf-grid-col-75\%-r\@lg {
+    .dcf-col-75\%-end\@lg {
       grid-column: span 9 / -1; } }
   @media only screen and (min-width: 99.375em) {
     .dcf-grid-halves\@xl {
@@ -730,25 +730,25 @@ th {
       grid-template-columns: repeat(5, 1fr); }
     .dcf-grid-sixths\@xl {
       grid-template-columns: repeat(6, 1fr); }
-    .dcf-grid-col-50\%-l\@xl {
+    .dcf-col-50\%-start\@xl {
       grid-column: 1 / span 6; }
-    .dcf-grid-col-50\%-r\@xl {
+    .dcf-col-50\%-end\@xl {
       grid-column: span 6 / -1; }
-    .dcf-grid-col-33\%-l\@xl {
+    .dcf-col-33\%-start\@xl {
       grid-column: 1 / span 4; }
-    .dcf-grid-col-33\%-r\@xl {
+    .dcf-col-33\%-end\@xl {
       grid-column: span 4 / -1; }
-    .dcf-grid-col-67\%-l\@xl {
+    .dcf-col-67\%-start\@xl {
       grid-column: 1 / span 8; }
-    .dcf-grid-col-67\%-r\@xl {
+    .dcf-col-67\%-end\@xl {
       grid-column: span 8 / -1; }
-    .dcf-grid-col-25\%-l\@xl {
+    .dcf-col-25\%-start\@xl {
       grid-column: 1 / span 3; }
-    .dcf-grid-col-25\%-r\@xl {
+    .dcf-col-25\%-end\@xl {
       grid-column: span 3 / -1; }
-    .dcf-grid-col-75\%-l\@xl {
+    .dcf-col-75\%-start\@xl {
       grid-column: 1 / span 9; }
-    .dcf-grid-col-75\%-r\@xl {
+    .dcf-col-75\%-end\@xl {
       grid-column: span 9 / -1; } } }
 
 .dcf-stretch {

--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -870,12 +870,12 @@
       <p>Grid-related object classes can be appended with the framework's responsive suffixes (<code>@sm</code>, <code>@md</code>, <code>@lg</code> and <code>@xl</code>) to apply styles at the respective breakpoints.</p>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-50%-l</code></dt>
+        <dt><code>.dcf-col-50%-start</code></dt>
         <dd>Apply to a grid child element to define the column width as one-half of the grid and locate it on the left side, at the start of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
-          <div class="dcf-grid-col-50%-l dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-50%-l</code></div>
+          <div class="dcf-col-50%-start dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-50%-start</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">2</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
@@ -898,13 +898,13 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-50%-r</code></dt>
+        <dt><code>.dcf-col-50%-end</code></dt>
         <dd>Apply to a grid child element to define the column width as one-half of the grid and locate it on the right side, at the end of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">1</span></div>
-          <div class="dcf-grid-col-50%-r dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-50%-r</code></div>
+          <div class="dcf-col-50%-end dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-50%-end</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">5</span></div>
@@ -926,12 +926,12 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-33%-l</code></dt>
+        <dt><code>.dcf-col-33%-start</code></dt>
         <dd>Apply to a grid child element to define the column width as one-third of the grid and locate it on the left side, at the start of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
-          <div class="dcf-grid-col-33%-l dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-33%-l</code></div>
+          <div class="dcf-col-33%-start dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-33%-start</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">2</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
@@ -954,13 +954,13 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-33%-r</code></dt>
+        <dt><code>.dcf-col-33%-end</code></dt>
         <dd>Apply to a grid child element to define the column width as one-third of the grid and locate it on the right side, at the end of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">1</span></div>
-          <div class="dcf-grid-col-33%-r dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-33%-r</code></div>
+          <div class="dcf-col-33%-end dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-33%-end</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">5</span></div>
@@ -982,12 +982,12 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-67%-l</code></dt>
+        <dt><code>.dcf-col-67%-start</code></dt>
         <dd>Apply to a grid child element to define the column width as two-thirds of the grid and locate it on the left side, at the start of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
-          <div class="dcf-grid-col-67%-l dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-67%-l</code></div>
+          <div class="dcf-col-67%-start dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-67%-start</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">2</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
@@ -1010,13 +1010,13 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-67%-r</code></dt>
+        <dt><code>.dcf-col-67%-end</code></dt>
         <dd>Apply to a grid child element to define the column width as two-thirds of the grid and locate it on the right side, at the end of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">1</span></div>
-          <div class="dcf-grid-col-67%-r dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-67%-r</code></div>
+          <div class="dcf-col-67%-end dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-67%-end</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">5</span></div>
@@ -1038,12 +1038,12 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-25%-l</code></dt>
+        <dt><code>.dcf-col-25%-start</code></dt>
         <dd>Apply to a grid child element to define the column width as one-fourth of the grid and locate it on the left side, at the start of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
-          <div class="dcf-grid-col-25%-l dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-25%-l</code></div>
+          <div class="dcf-col-25%-start dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-25%-start</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">2</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
@@ -1066,13 +1066,13 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-25%-r</code></dt>
+        <dt><code>.dcf-col-25%-end</code></dt>
         <dd>Apply to a grid child element to define the column width as one-fourth of the grid and locate it on the right side, at the end of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">1</span></div>
-          <div class="dcf-grid-col-25%-r dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-25%-r</code></div>
+          <div class="dcf-col-25%-end dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-25%-end</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">5</span></div>
@@ -1094,12 +1094,12 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-75%-l</code></dt>
+        <dt><code>.dcf-col-75%-start</code></dt>
         <dd>Apply to a grid child element to define the column width as three-fourths of the grid and locate it on the left side, at the start of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
-          <div class="dcf-grid-col-75%-l dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-75%-l</code></div>
+          <div class="dcf-col-75%-start dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-75%-start</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">2</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
@@ -1122,13 +1122,13 @@
       </figure>
 
       <dl class="dcf-mt-8">
-        <dt><code>.dcf-grid-col-75%-r</code></dt>
+        <dt><code>.dcf-col-75%-end</code></dt>
         <dd>Apply to a grid child element to define the column width as three-fourths of the grid and locate it on the right side, at the end of the grid's tracks.</dd>
       </dl>
       <figure class="dcf-mt-6">
         <div class="dcf-grid dcf-col-gap-sm dcf-row-gap-sm">
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">1</span></div>
-          <div class="dcf-grid-col-75%-r dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-grid-col-75%-r</code></div>
+          <div class="dcf-col-75%-end dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><code class="dcf-bold dcf-txt-sm">.dcf-col-75%-end</code></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">3</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">4</span></div>
           <div class="dcf-d-flex dcf-ai-center dcf-jc-center dcf-pt-2 dcf-pb-2 dcf-b-1"><span class="dcf-txt-sm">5</span></div>


### PR DESCRIPTION
Use [logical properties/values](https://www.smashingmagazine.com/2018/03/understanding-logical-properties-values/) to describe grid column placement instead of physical dimensions (e.g. left, right, top, bottom).