### PR TITLE
Documentation updates

### DIFF
--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -2500,7 +2500,7 @@
 		        <dt><code>.dcf-h-7</code></dt><dd>height: 2.37em</dd>
 		        <dt><code>.dcf-h-8</code></dt><dd>height: 3.16em</dd>
 		        <dt><code>.dcf-h-9</code></dt><dd>height: 4.21em</dd>
-		        <dt><code>.dcf-h-10</code></dt><dd>height: 5.61em</dd>
+		        <dt><code>.dcf-h-10</code></dt><dd>height: 5.62em</dd>
 		        <dt><code>.dcf-h-100%</code></dt><dd>height: 100%</dd>
 		        <dt><code>.dcf-h-100vh</code></dt><dd>height: 100vw</dd>
 		      </dl>
@@ -2531,7 +2531,7 @@
 		        <dt><code>.dcf-w-7</code></dt><dd>width: 2.37em</dd>
 		        <dt><code>.dcf-w-8</code></dt><dd>width: 3.16em</dd>
 		        <dt><code>.dcf-w-9</code></dt><dd>width: 4.21em</dd>
-		        <dt><code>.dcf-w-10</code></dt><dd>width: 5.61em</dd>
+		        <dt><code>.dcf-w-10</code></dt><dd>width: 5.62em</dd>
 		        <dt><code>.dcf-w-100%</code></dt><dd>width: 100%</dd>
 		        <dt><code>.dcf-w-100vw</code></dt><dd>width: 100vw</dd>
 		      </dl>
@@ -2566,7 +2566,7 @@
             <dt><code>.dcf-m-7</code></dt><dd>margin (all sides): 2.37em</dd>
             <dt><code>.dcf-m-8</code></dt><dd>margin (all sides): 3.16em</dd>
             <dt><code>.dcf-m-9</code></dt><dd>margin (all sides): 4.21em</dd>
-            <dt><code>.dcf-m-10</code></dt><dd>margin (all sides): 5.61em</dd>
+            <dt><code>.dcf-m-10</code></dt><dd>margin (all sides): 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2582,7 +2582,7 @@
             <dt><code>.dcf-mt-7</code></dt><dd>margin-top: 2.37em</dd>
             <dt><code>.dcf-mt-8</code></dt><dd>margin-top: 3.16em</dd>
             <dt><code>.dcf-mt-9</code></dt><dd>margin-top: 4.21em</dd>
-            <dt><code>.dcf-mt-10</code></dt><dd>margin-top: 5.61em</dd>
+            <dt><code>.dcf-mt-10</code></dt><dd>margin-top: 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2598,7 +2598,7 @@
             <dt><code>.dcf-mr-7</code></dt><dd>margin-right: 2.37em</dd>
             <dt><code>.dcf-mr-8</code></dt><dd>margin-right: 3.16em</dd>
             <dt><code>.dcf-mr-9</code></dt><dd>margin-right: 4.21em</dd>
-            <dt><code>.dcf-mr-10</code></dt><dd>margin-right: 5.61em</dd>
+            <dt><code>.dcf-mr-10</code></dt><dd>margin-right: 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2614,7 +2614,7 @@
             <dt><code>.dcf-mb-7</code></dt><dd>margin-bottom: 2.37em</dd>
             <dt><code>.dcf-mb-8</code></dt><dd>margin-bottom: 3.16em</dd>
             <dt><code>.dcf-mb-9</code></dt><dd>margin-bottom: 4.21em</dd>
-            <dt><code>.dcf-mb-10</code></dt><dd>margin-bottom: 5.61em</dd>
+            <dt><code>.dcf-mb-10</code></dt><dd>margin-bottom: 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2630,7 +2630,7 @@
             <dt><code>.dcf-ml-7</code></dt><dd>margin-left: 2.37em</dd>
             <dt><code>.dcf-ml-8</code></dt><dd>margin-left: 3.16em</dd>
             <dt><code>.dcf-ml-9</code></dt><dd>margin-left: 4.21em</dd>
-            <dt><code>.dcf-ml-10</code></dt><dd>margin-left: 5.61em</dd>
+            <dt><code>.dcf-ml-10</code></dt><dd>margin-left: 5.62em</dd>
           </dl>
         </div>
       </div>
@@ -2689,7 +2689,7 @@
             <dt><code>.dcf-p-7</code></dt><dd>padding (all sides): 2.37em</dd>
             <dt><code>.dcf-p-8</code></dt><dd>padding (all sides): 3.16em</dd>
             <dt><code>.dcf-p-9</code></dt><dd>padding (all sides): 4.21em</dd>
-            <dt><code>.dcf-p-10</code></dt><dd>padding (all sides): 5.61em</dd>
+            <dt><code>.dcf-p-10</code></dt><dd>padding (all sides): 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2705,7 +2705,7 @@
             <dt><code>.dcf-pt-7</code></dt><dd>padding-top: 2.37em</dd>
             <dt><code>.dcf-pt-8</code></dt><dd>padding-top: 3.16em</dd>
             <dt><code>.dcf-pt-9</code></dt><dd>padding-top: 4.21em</dd>
-            <dt><code>.dcf-pt-10</code></dt><dd>padding-top: 5.61em</dd>
+            <dt><code>.dcf-pt-10</code></dt><dd>padding-top: 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2721,7 +2721,7 @@
             <dt><code>.dcf-pr-7</code></dt><dd>padding-right: 2.37em</dd>
             <dt><code>.dcf-pr-8</code></dt><dd>padding-right: 3.16em</dd>
             <dt><code>.dcf-pr-9</code></dt><dd>padding-right: 4.21em</dd>
-            <dt><code>.dcf-pr-10</code></dt><dd>padding-right: 5.61em</dd>
+            <dt><code>.dcf-pr-10</code></dt><dd>padding-right: 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2736,7 +2736,7 @@
             <dt><code>.dcf-pb-6</code></dt><dd>padding-bottom: 1.77em</dd>
             <dt><code>.dcf-pb-7</code></dt><dd>padding-bottom: 2.37em</dd>
             <dt><code>.dcf-pb-8</code></dt><dd>padding-bottom: 3.16em</dd>
-            <dt><code>.dcf-pb-10</code></dt><dd>padding-bottom: 5.61em</dd>
+            <dt><code>.dcf-pb-10</code></dt><dd>padding-bottom: 5.62em</dd>
           </dl>
         </div>
         <div>
@@ -2752,7 +2752,7 @@
             <dt><code>.dcf-pl-7</code></dt><dd>padding-left: 2.37em</dd>
             <dt><code>.dcf-pl-8</code></dt><dd>padding-left: 3.16em</dd>
             <dt><code>.dcf-pl-9</code></dt><dd>padding-left: 4.21em</dd>
-            <dt><code>.dcf-pl-10</code></dt><dd>padding-left: 5.61em</dd>
+            <dt><code>.dcf-pl-10</code></dt><dd>padding-left: 5.62em</dd>
           </dl>
         </div>
       </div>

--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -2556,81 +2556,81 @@
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-margin-all">Margin (All Sides)</h4>
           <dl>
-            <dt><code>.dcf-m-0</code></dt><dd>margin (all sides), value 0</dd>
-            <dt><code>.dcf-m-1</code></dt><dd>margin (all sides), value 1</dd>
-            <dt><code>.dcf-m-2</code></dt><dd>margin (all sides), value 2</dd>
-            <dt><code>.dcf-m-3</code></dt><dd>margin (all sides), value 3</dd>
-            <dt><code>.dcf-m-4</code></dt><dd>margin (all sides), value 4</dd>
-            <dt><code>.dcf-m-5</code></dt><dd>margin (all sides), value 5</dd>
-            <dt><code>.dcf-m-6</code></dt><dd>margin (all sides), value 6</dd>
-            <dt><code>.dcf-m-7</code></dt><dd>margin (all sides), value 7</dd>
-            <dt><code>.dcf-m-8</code></dt><dd>margin (all sides), value 8</dd>
-            <dt><code>.dcf-m-9</code></dt><dd>margin (all sides), value 9</dd>
-            <dt><code>.dcf-m-10</code></dt><dd>margin (all sides), value 10</dd>
+            <dt><code>.dcf-m-0</code></dt><dd>margin (all sides): 0</dd>
+            <dt><code>.dcf-m-1</code></dt><dd>margin (all sides): .42em</dd>
+            <dt><code>.dcf-m-2</code></dt><dd>margin (all sides): .56em</dd>
+            <dt><code>.dcf-m-3</code></dt><dd>margin (all sides): .75em</dd>
+            <dt><code>.dcf-m-4</code></dt><dd>margin (all sides): 1em</dd>
+            <dt><code>.dcf-m-5</code></dt><dd>margin (all sides): 1.33em</dd>
+            <dt><code>.dcf-m-6</code></dt><dd>margin (all sides): 1.77em</dd>
+            <dt><code>.dcf-m-7</code></dt><dd>margin (all sides): 2.37em</dd>
+            <dt><code>.dcf-m-8</code></dt><dd>margin (all sides): 3.16em</dd>
+            <dt><code>.dcf-m-9</code></dt><dd>margin (all sides): 4.21em</dd>
+            <dt><code>.dcf-m-10</code></dt><dd>margin (all sides): 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-margin-top">Margin Top</h4>
           <dl>
-            <dt><code>.dcf-mt-0</code></dt><dd>margin-top, value 0</dd>
-            <dt><code>.dcf-mt-1</code></dt><dd>margin-top, value 1</dd>
-            <dt><code>.dcf-mt-2</code></dt><dd>margin-top, value 2</dd>
-            <dt><code>.dcf-mt-3</code></dt><dd>margin-top, value 3</dd>
-            <dt><code>.dcf-mt-4</code></dt><dd>margin-top, value 4</dd>
-            <dt><code>.dcf-mt-5</code></dt><dd>margin-top, value 5</dd>
-            <dt><code>.dcf-mt-6</code></dt><dd>margin-top, value 6</dd>
-            <dt><code>.dcf-mt-7</code></dt><dd>margin-top, value 7</dd>
-            <dt><code>.dcf-mt-8</code></dt><dd>margin-top, value 8</dd>
-            <dt><code>.dcf-mt-9</code></dt><dd>margin-top, value 9</dd>
-            <dt><code>.dcf-mt-10</code></dt><dd>margin-top, value 10</dd>
+            <dt><code>.dcf-mt-0</code></dt><dd>margin-top: 0</dd>
+            <dt><code>.dcf-mt-1</code></dt><dd>margin-top: .42em</dd>
+            <dt><code>.dcf-mt-2</code></dt><dd>margin-top: .56em</dd>
+            <dt><code>.dcf-mt-3</code></dt><dd>margin-top: .75em</dd>
+            <dt><code>.dcf-mt-4</code></dt><dd>margin-top: 1em</dd>
+            <dt><code>.dcf-mt-5</code></dt><dd>margin-top: 1.33em</dd>
+            <dt><code>.dcf-mt-6</code></dt><dd>margin-top: 1.77em</dd>
+            <dt><code>.dcf-mt-7</code></dt><dd>margin-top: 2.37em</dd>
+            <dt><code>.dcf-mt-8</code></dt><dd>margin-top: 3.16em</dd>
+            <dt><code>.dcf-mt-9</code></dt><dd>margin-top: 4.21em</dd>
+            <dt><code>.dcf-mt-10</code></dt><dd>margin-top: 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-margin-right">Margin Right</h4>
           <dl>
-            <dt><code>.dcf-mr-0</code></dt><dd>margin-right, value 0</dd>
-            <dt><code>.dcf-mr-1</code></dt><dd>margin-right, value 1</dd>
-            <dt><code>.dcf-mr-2</code></dt><dd>margin-right, value 2</dd>
-            <dt><code>.dcf-mr-3</code></dt><dd>margin-right, value 3</dd>
-            <dt><code>.dcf-mr-4</code></dt><dd>margin-right, value 4</dd>
-            <dt><code>.dcf-mr-5</code></dt><dd>margin-right, value 5</dd>
-            <dt><code>.dcf-mr-6</code></dt><dd>margin-right, value 6</dd>
-            <dt><code>.dcf-mr-7</code></dt><dd>margin-right, value 7</dd>
-            <dt><code>.dcf-mr-8</code></dt><dd>margin-right, value 8</dd>
-            <dt><code>.dcf-mr-9</code></dt><dd>margin-right, value 9</dd>
-            <dt><code>.dcf-mr-10</code></dt><dd>margin-right, value 10</dd>
+            <dt><code>.dcf-mr-0</code></dt><dd>margin-right: 0</dd>
+            <dt><code>.dcf-mr-1</code></dt><dd>margin-right: .42em</dd>
+            <dt><code>.dcf-mr-2</code></dt><dd>margin-right: .56em</dd>
+            <dt><code>.dcf-mr-3</code></dt><dd>margin-right: .75em</dd>
+            <dt><code>.dcf-mr-4</code></dt><dd>margin-right: 1em</dd>
+            <dt><code>.dcf-mr-5</code></dt><dd>margin-right: 1.33em</dd>
+            <dt><code>.dcf-mr-6</code></dt><dd>margin-right: 1.77em</dd>
+            <dt><code>.dcf-mr-7</code></dt><dd>margin-right: 2.37em</dd>
+            <dt><code>.dcf-mr-8</code></dt><dd>margin-right: 3.16em</dd>
+            <dt><code>.dcf-mr-9</code></dt><dd>margin-right: 4.21em</dd>
+            <dt><code>.dcf-mr-10</code></dt><dd>margin-right: 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-margin-bottom">Margin Bottom</h4>
           <dl>
-            <dt><code>.dcf-mb-0</code></dt><dd>margin-bottom, value 0</dd>
-            <dt><code>.dcf-mb-1</code></dt><dd>margin-bottom, value 1</dd>
-            <dt><code>.dcf-mb-2</code></dt><dd>margin-bottom, value 2</dd>
-            <dt><code>.dcf-mb-3</code></dt><dd>margin-bottom, value 3</dd>
-            <dt><code>.dcf-mb-4</code></dt><dd>margin-bottom, value 4</dd>
-            <dt><code>.dcf-mb-5</code></dt><dd>margin-bottom, value 5</dd>
-            <dt><code>.dcf-mb-6</code></dt><dd>margin-bottom, value 6</dd>
-            <dt><code>.dcf-mb-7</code></dt><dd>margin-bottom, value 7</dd>
-            <dt><code>.dcf-mb-8</code></dt><dd>margin-bottom, value 8</dd>
-            <dt><code>.dcf-mb-9</code></dt><dd>margin-bottom, value 9</dd>
-            <dt><code>.dcf-mb-10</code></dt><dd>margin-bottom, value 10</dd>
+            <dt><code>.dcf-mb-0</code></dt><dd>margin-bottom: 0</dd>
+            <dt><code>.dcf-mb-1</code></dt><dd>margin-bottom: .42em</dd>
+            <dt><code>.dcf-mb-2</code></dt><dd>margin-bottom: .56em</dd>
+            <dt><code>.dcf-mb-3</code></dt><dd>margin-bottom: .75em</dd>
+            <dt><code>.dcf-mb-4</code></dt><dd>margin-bottom: 1em</dd>
+            <dt><code>.dcf-mb-5</code></dt><dd>margin-bottom: 1.33em</dd>
+            <dt><code>.dcf-mb-6</code></dt><dd>margin-bottom: 1.77em</dd>
+            <dt><code>.dcf-mb-7</code></dt><dd>margin-bottom: 2.37em</dd>
+            <dt><code>.dcf-mb-8</code></dt><dd>margin-bottom: 3.16em</dd>
+            <dt><code>.dcf-mb-9</code></dt><dd>margin-bottom: 4.21em</dd>
+            <dt><code>.dcf-mb-10</code></dt><dd>margin-bottom: 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-margin-left">Margin Left</h4>
           <dl>
-            <dt><code>.dcf-ml-0</code></dt><dd>margin-left, value 0</dd>
-            <dt><code>.dcf-ml-1</code></dt><dd>margin-left, value 1</dd>
-            <dt><code>.dcf-ml-2</code></dt><dd>margin-left, value 2</dd>
-            <dt><code>.dcf-ml-3</code></dt><dd>margin-left, value 3</dd>
-            <dt><code>.dcf-ml-4</code></dt><dd>margin-left, value 4</dd>
-            <dt><code>.dcf-ml-5</code></dt><dd>margin-left, value 5</dd>
-            <dt><code>.dcf-ml-6</code></dt><dd>margin-left, value 6</dd>
-            <dt><code>.dcf-ml-7</code></dt><dd>margin-left, value 7</dd>
-            <dt><code>.dcf-ml-8</code></dt><dd>margin-left, value 8</dd>
-            <dt><code>.dcf-ml-9</code></dt><dd>margin-left, value 9</dd>
-            <dt><code>.dcf-ml-10</code></dt><dd>margin-left, value 10</dd>
+            <dt><code>.dcf-ml-0</code></dt><dd>margin-left: 0</dd>
+            <dt><code>.dcf-ml-1</code></dt><dd>margin-left: .42em</dd>
+            <dt><code>.dcf-ml-2</code></dt><dd>margin-left: .56em</dd>
+            <dt><code>.dcf-ml-3</code></dt><dd>margin-left: .75em</dd>
+            <dt><code>.dcf-ml-4</code></dt><dd>margin-left: 1em</dd>
+            <dt><code>.dcf-ml-5</code></dt><dd>margin-left: 1.33em</dd>
+            <dt><code>.dcf-ml-6</code></dt><dd>margin-left: 1.77em</dd>
+            <dt><code>.dcf-ml-7</code></dt><dd>margin-left: 2.37em</dd>
+            <dt><code>.dcf-ml-8</code></dt><dd>margin-left: 3.16em</dd>
+            <dt><code>.dcf-ml-9</code></dt><dd>margin-left: 4.21em</dd>
+            <dt><code>.dcf-ml-10</code></dt><dd>margin-left: 5.61em</dd>
           </dl>
         </div>
       </div>
@@ -2679,80 +2679,80 @@
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-padding-all">Padding (All Sides)</h4>
           <dl>
-            <dt><code>.dcf-p-0</code></dt><dd>padding (all sides), value 0</dd>
-            <dt><code>.dcf-p-1</code></dt><dd>padding (all sides), value 1</dd>
-            <dt><code>.dcf-p-2</code></dt><dd>padding (all sides), value 2</dd>
-            <dt><code>.dcf-p-3</code></dt><dd>padding (all sides), value 3</dd>
-            <dt><code>.dcf-p-4</code></dt><dd>padding (all sides), value 4</dd>
-            <dt><code>.dcf-p-5</code></dt><dd>padding (all sides), value 5</dd>
-            <dt><code>.dcf-p-6</code></dt><dd>padding (all sides), value 6</dd>
-            <dt><code>.dcf-p-7</code></dt><dd>padding (all sides), value 7</dd>
-            <dt><code>.dcf-p-8</code></dt><dd>padding (all sides), value 8</dd>
-            <dt><code>.dcf-p-9</code></dt><dd>padding (all sides), value 9</dd>
-            <dt><code>.dcf-p-10</code></dt><dd>padding (all sides), value 10</dd>
+            <dt><code>.dcf-p-0</code></dt><dd>padding (all sides): 0</dd>
+            <dt><code>.dcf-p-1</code></dt><dd>padding (all sides): .42em</dd>
+            <dt><code>.dcf-p-2</code></dt><dd>padding (all sides): .56em</dd>
+            <dt><code>.dcf-p-3</code></dt><dd>padding (all sides): .75em</dd>
+            <dt><code>.dcf-p-4</code></dt><dd>padding (all sides): 1em</dd>
+            <dt><code>.dcf-p-5</code></dt><dd>padding (all sides): 1.33em</dd>
+            <dt><code>.dcf-p-6</code></dt><dd>padding (all sides): 1.77em</dd>
+            <dt><code>.dcf-p-7</code></dt><dd>padding (all sides): 2.37em</dd>
+            <dt><code>.dcf-p-8</code></dt><dd>padding (all sides): 3.16em</dd>
+            <dt><code>.dcf-p-9</code></dt><dd>padding (all sides): 4.21em</dd>
+            <dt><code>.dcf-p-10</code></dt><dd>padding (all sides): 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-padding-top">Padding Top</h4>
           <dl>
-            <dt><code>.dcf-pt-0</code></dt><dd>padding-top, value 0</dd>
-            <dt><code>.dcf-pt-1</code></dt><dd>padding-top, value 1</dd>
-            <dt><code>.dcf-pt-2</code></dt><dd>padding-top, value 2</dd>
-            <dt><code>.dcf-pt-3</code></dt><dd>padding-top, value 3</dd>
-            <dt><code>.dcf-pt-4</code></dt><dd>padding-top, value 4</dd>
-            <dt><code>.dcf-pt-5</code></dt><dd>padding-top, value 5</dd>
-            <dt><code>.dcf-pt-6</code></dt><dd>padding-top, value 6</dd>
-            <dt><code>.dcf-pt-7</code></dt><dd>padding-top, value 7</dd>
-            <dt><code>.dcf-pt-8</code></dt><dd>padding-top, value 8</dd>
-            <dt><code>.dcf-pt-9</code></dt><dd>padding-top, value 9</dd>
-            <dt><code>.dcf-pt-10</code></dt><dd>padding-top, value 10</dd>
+            <dt><code>.dcf-pt-0</code></dt><dd>padding-top: 0</dd>
+            <dt><code>.dcf-pt-1</code></dt><dd>padding-top: .42em</dd>
+            <dt><code>.dcf-pt-2</code></dt><dd>padding-top: .56em</dd>
+            <dt><code>.dcf-pt-3</code></dt><dd>padding-top: .75em</dd>
+            <dt><code>.dcf-pt-4</code></dt><dd>padding-top: 1em</dd>
+            <dt><code>.dcf-pt-5</code></dt><dd>padding-top: 1.33em</dd>
+            <dt><code>.dcf-pt-6</code></dt><dd>padding-top: 1.77em</dd>
+            <dt><code>.dcf-pt-7</code></dt><dd>padding-top: 2.37em</dd>
+            <dt><code>.dcf-pt-8</code></dt><dd>padding-top: 3.16em</dd>
+            <dt><code>.dcf-pt-9</code></dt><dd>padding-top: 4.21em</dd>
+            <dt><code>.dcf-pt-10</code></dt><dd>padding-top: 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-padding-right">Padding Right</h4>
           <dl>
-            <dt><code>.dcf-pr-0</code></dt><dd>padding-right, value 0</dd>
-            <dt><code>.dcf-pr-1</code></dt><dd>padding-right, value 1</dd>
-            <dt><code>.dcf-pr-2</code></dt><dd>padding-right, value 2</dd>
-            <dt><code>.dcf-pr-3</code></dt><dd>padding-right, value 3</dd>
-            <dt><code>.dcf-pr-4</code></dt><dd>padding-right, value 4</dd>
-            <dt><code>.dcf-pr-5</code></dt><dd>padding-right, value 5</dd>
-            <dt><code>.dcf-pr-6</code></dt><dd>padding-right, value 6</dd>
-            <dt><code>.dcf-pr-7</code></dt><dd>padding-right, value 7</dd>
-            <dt><code>.dcf-pr-8</code></dt><dd>padding-right, value 8</dd>
-            <dt><code>.dcf-pr-9</code></dt><dd>padding-right, value 9</dd>
-            <dt><code>.dcf-pr-10</code></dt><dd>padding-right, value 10</dd>
+            <dt><code>.dcf-pr-0</code></dt><dd>padding-right: 0</dd>
+            <dt><code>.dcf-pr-1</code></dt><dd>padding-right: .42em</dd>
+            <dt><code>.dcf-pr-2</code></dt><dd>padding-right: .56em</dd>
+            <dt><code>.dcf-pr-3</code></dt><dd>padding-right: .75em</dd>
+            <dt><code>.dcf-pr-4</code></dt><dd>padding-right: 1em</dd>
+            <dt><code>.dcf-pr-5</code></dt><dd>padding-right: 1.33em</dd>
+            <dt><code>.dcf-pr-6</code></dt><dd>padding-right: 1.77em</dd>
+            <dt><code>.dcf-pr-7</code></dt><dd>padding-right: 2.37em</dd>
+            <dt><code>.dcf-pr-8</code></dt><dd>padding-right: 3.16em</dd>
+            <dt><code>.dcf-pr-9</code></dt><dd>padding-right: 4.21em</dd>
+            <dt><code>.dcf-pr-10</code></dt><dd>padding-right: 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-padding-bottom">Padding Bottom</h4>
           <dl>
-            <dt><code>.dcf-pb-0</code></dt><dd>padding-bottom, value 0</dd>
-            <dt><code>.dcf-pb-1</code></dt><dd>padding-bottom, value 1</dd>
-            <dt><code>.dcf-pb-2</code></dt><dd>padding-bottom, value 2</dd>
-            <dt><code>.dcf-pb-3</code></dt><dd>padding-bottom, value 3</dd>
-            <dt><code>.dcf-pb-4</code></dt><dd>padding-bottom, value 4</dd>
-            <dt><code>.dcf-pb-5</code></dt><dd>padding-bottom, value 5</dd>
-            <dt><code>.dcf-pb-6</code></dt><dd>padding-bottom, value 6</dd>
-            <dt><code>.dcf-pb-7</code></dt><dd>padding-bottom, value 7</dd>
-            <dt><code>.dcf-pb-8</code></dt><dd>padding-bottom, value 8</dd>
-            <dt><code>.dcf-pb-10</code></dt><dd>padding-bottom, value 10</dd>
+            <dt><code>.dcf-pb-0</code></dt><dd>padding-bottom: 0</dd>
+            <dt><code>.dcf-pb-1</code></dt><dd>padding-bottom: .42em</dd>
+            <dt><code>.dcf-pb-2</code></dt><dd>padding-bottom: .56em</dd>
+            <dt><code>.dcf-pb-3</code></dt><dd>padding-bottom: .75em</dd>
+            <dt><code>.dcf-pb-4</code></dt><dd>padding-bottom: 1em</dd>
+            <dt><code>.dcf-pb-5</code></dt><dd>padding-bottom: 1.33em</dd>
+            <dt><code>.dcf-pb-6</code></dt><dd>padding-bottom: 1.77em</dd>
+            <dt><code>.dcf-pb-7</code></dt><dd>padding-bottom: 2.37em</dd>
+            <dt><code>.dcf-pb-8</code></dt><dd>padding-bottom: 3.16em</dd>
+            <dt><code>.dcf-pb-10</code></dt><dd>padding-bottom: 5.61em</dd>
           </dl>
         </div>
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-padding-left">Padding Left</h4>
           <dl>
-            <dt><code>.dcf-pl-0</code></dt><dd>padding-left, value 0</dd>
-            <dt><code>.dcf-pl-1</code></dt><dd>padding-left, value 1</dd>
-            <dt><code>.dcf-pl-2</code></dt><dd>padding-left, value 2</dd>
-            <dt><code>.dcf-pl-3</code></dt><dd>padding-left, value 3</dd>
-            <dt><code>.dcf-pl-4</code></dt><dd>padding-left, value 4</dd>
-            <dt><code>.dcf-pl-5</code></dt><dd>padding-left, value 5</dd>
-            <dt><code>.dcf-pl-6</code></dt><dd>padding-left, value 6</dd>
-            <dt><code>.dcf-pl-7</code></dt><dd>padding-left, value 7</dd>
-            <dt><code>.dcf-pl-8</code></dt><dd>padding-left, value 8</dd>
-            <dt><code>.dcf-pl-9</code></dt><dd>padding-left, value 9</dd>
-            <dt><code>.dcf-pl-10</code></dt><dd>padding-left, value 10</dd>
+            <dt><code>.dcf-pl-0</code></dt><dd>padding-left: 0</dd>
+            <dt><code>.dcf-pl-1</code></dt><dd>padding-left: .42em</dd>
+            <dt><code>.dcf-pl-2</code></dt><dd>padding-left: .56em</dd>
+            <dt><code>.dcf-pl-3</code></dt><dd>padding-left: .75em</dd>
+            <dt><code>.dcf-pl-4</code></dt><dd>padding-left: 1em</dd>
+            <dt><code>.dcf-pl-5</code></dt><dd>padding-left: 1.33em</dd>
+            <dt><code>.dcf-pl-6</code></dt><dd>padding-left: 1.77em</dd>
+            <dt><code>.dcf-pl-7</code></dt><dd>padding-left: 2.37em</dd>
+            <dt><code>.dcf-pl-8</code></dt><dd>padding-left: 3.16em</dd>
+            <dt><code>.dcf-pl-9</code></dt><dd>padding-left: 4.21em</dd>
+            <dt><code>.dcf-pl-10</code></dt><dd>padding-left: 5.61em</dd>
           </dl>
         </div>
       </div>

--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -2859,10 +2859,10 @@
         <div>
           <h4 class="dcf-mt-6" id="example-utilities-line-height">Line Height</h4>
           <dl>
-            <dt><code>.dcf-lh-1</code></dt><dd>tightest line-height</dd>
-            <dt><code>.dcf-lh-2</code></dt><dd>tighter line-height (e.g., headings)</dd>
-            <dt><code>.dcf-lh-3</code></dt><dd>medium line-height</dd>
-            <dt><code>.dcf-lh-4</code></dt><dd>regular line-height</dd>
+            <dt><code>.dcf-lh-1</code></dt><dd>line-height: 1</dd>
+            <dt><code>.dcf-lh-2</code></dt><dd>line-height: 1.13</dd>
+            <dt><code>.dcf-lh-3</code></dt><dd>line-height: 1.33</dd>
+            <dt><code>.dcf-lh-4</code></dt><dd>line-height: 1.5</dd>
           </dl>
         </div>
         <div>

--- a/theme/example/debug.shtml
+++ b/theme/example/debug.shtml
@@ -32,7 +32,7 @@
 
       <!--#include virtual="/dcf/theme/example/includes/global/institution.html" -->
 
-      <div class="dcf-d-flex dcf-ai-center dcf-pt-4 dcf-logo" style="overflow: hidden;">
+      <div class="dcf-d-flex dcf-ai-center dcf-pt-4 dcf-logo dcf-overflow-hidden">
         <!--#include virtual="/dcf/theme/example/includes/global/logo.html" -->
 
         <div class="dcf-d-flex dcf-flex-col dcf-jc-center">


### PR DESCRIPTION
- Replace logo lockup inline style with overflow utility
- Replace general margin/padding placeholders with numeric values
- Replace relative line-height descriptions with numeric values
- Round ‘5.61em’ values up to ‘5.62em’ for greater accuracy