### PR TITLE
- added the .dcf-ai-flex-start class to align label properly in Safari

### DIFF
--- a/example/index.shtml
+++ b/example/index.shtml
@@ -1878,7 +1878,7 @@
             </fieldset>
             <fieldset>
               <legend class="dcf-legend">Radio buttons</legend>
-              <div class="dcf-d-flex dcf-form-group dcf-input-group-form">
+              <div class="dcf-d-flex dcf-form-group dcf-input-group-form dcf-ai-flex-start">
                 <label for="position" id="position-level" class="dcf-label">I identify myself as a:
                 </label>
                 <fieldset id="Position" name="Position" aria-labelledby="position-level"


### PR DESCRIPTION
added the .dcf-ai-flex-start class to align label properly in Safari 