### PR TITLE
Fix engine syntax in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "object-fit-images": "^3.2.4"
   },
   "engines": {
-    "node": "node >= 0.10.0"
+    "node": ">= 0.10.0"
   },
   "browserslist": [
     "last 1 Chrome version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dcf",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Digital Campus Framework",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Current:
```
  "engines": {
    "node": "node >= 0.10.0"
  },
```

Proposed:
```
  "engines": {
    "node": ">= 0.10.0"
  },
```

When trying add d-c-n/dcf as a dependency with NPM, we get the following error:
```
Unsupported engine for dcf@1.0.0: wanted: {"node":"node >= 0.10.0"} (current: {"node":"13.0.1","npm":"6.12.0"})
Not compatible with your version of node/npm: dcf@1.0.0
```

Syntax docs: https://docs.npmjs.com/files/package.json#engines