### PR TITLE
Explicitly set input border-radius

### DIFF
--- a/scss/components/_components.forms-selects.scss
+++ b/scss/components/_components.forms-selects.scss
@@ -17,6 +17,8 @@
   border: $border-width-input solid $border-color-input;
   @if ($border-radius-input-roundrect) {
     border-radius: $roundrect;
+  } @else {
+    border-radius: 0;
   }
   box-sizing: border-box;
   color: $color-select;

--- a/scss/components/_components.forms.scss
+++ b/scss/components/_components.forms.scss
@@ -79,6 +79,8 @@
   border: $border-width-input $border-style-input $border-color-input;
   @if ($border-radius-input-roundrect) {
     border-radius: $roundrect;
+  } @else {
+    border-radius: 0;
   }
 }
 


### PR DESCRIPTION
Ensure that browser defaults are overridden by explicitly setting `border-radius` for text `input` and `select`.