### PR TITLE
Import testForWebP to dcf

### DIFF
--- a/js/dcf-test-for-webp.js
+++ b/js/dcf-test-for-webp.js
@@ -7,9 +7,8 @@ class DCFTestForWebp {
   }
   initialize() {
     (function ad(document) {
-      'use strict';
       function alreadyTested() {
-        return !!window.sessionStorage && !!window.sessionStorage.getItem('webpSupport');
+        return Boolean(window.sessionStorage) && Boolean(window.sessionStorage.getItem('webpSupport'));
       }
       // Add 'webp' class to html element if not supported.
       // Add 'no-webp' class to html element if not supported.

--- a/js/dcf-test-for-webp.js
+++ b/js/dcf-test-for-webp.js
@@ -6,7 +6,7 @@ class DCFTestForWebp {
     this.document = document;
   }
   initialize() {
-    (function ad(document) {
+    (function(document) {
       function alreadyTested() {
         return Boolean(window.sessionStorage) && Boolean(window.sessionStorage.getItem('webpSupport'));
       }

--- a/js/dcf-test-for-webp.js
+++ b/js/dcf-test-for-webp.js
@@ -1,0 +1,49 @@
+// Test for WebP browser support
+// Slightly modified https://github.com/djpogo/webp-inline-support
+
+class DCFTestForWebp {
+  constructor(document) {
+    this.document = document;
+  }
+  initialize() {
+    (function ad(document) {
+      'use strict';
+      function alreadyTested() {
+        return !!window.sessionStorage && !!window.sessionStorage.getItem('webpSupport');
+      }
+      // Add 'webp' class to html element if not supported.
+      // Add 'no-webp' class to html element if not supported.
+
+      function addWebPClass(support) {
+        let el = document.documentElement;
+
+        if (support) {
+          if (el.classList) {
+            el.classList.add('dcf-webp');
+          } else {
+            el.className = `${el.className} dcf-webp`;
+          }
+          window.sessionStorage.setItem('webpSupport', true);
+        } else if (el.classList) {
+          el.classList.add('dcf-no-webp');
+        } else {
+          el.className = `${el.className} dcf-no-webp`;
+        }
+      }
+
+      function testWebP(callback) {
+        if (alreadyTested()) {
+          addWebPClass(true);
+          return;
+        }
+        let webP = new Image();
+        webP.onload = webP.onerror = function callbackFunction() {
+          callback(webP.height === DCFUtility.magicNumbers('int2'));
+        };
+        webP.src = 'data:image/webp;base64,UklGRi4AAABXRUJQVlA4TCEAAAAvAUAAEB8wA' +
+          'iMwAgSSNtse/cXjxyCCmrYNWPwmHRH9jwMA';
+      }
+      testWebP(addWebPClass);
+    }(document));
+  }
+}

--- a/js/dcf-utility.js
+++ b/js/dcf-utility.js
@@ -4,6 +4,7 @@ class DCFUtility {
     const magicNumbers = {
       int0: 0,
       int1: 1,
+      int2: 2,
       int16: 16,
       hex0x3: 0x3,
       hex0x8: 0x8,


### PR DESCRIPTION
Imported testForWebP into dcf and added formatting to comply with lintJS.
I am not sure if `'use strict';` is still needed after the function(document) line.