### PR TITLE
Update classes added/removed when lazy-loaded

### DIFF
--- a/js/dcf-lazyLoad.js
+++ b/js/dcf-lazyLoad.js
@@ -34,11 +34,9 @@ class DCFLazyLoad {
       this.applyPicture(image.parentNode);
     }
 
-    // Prevent this from being lazy loaded a second time and trigger fade in.
-    image.classList.add('dcf-lazy-loaded', 'dcf-faded-in');
-
-    // Remove dcf-fade-in class since added dcf-faded-in
-    image.classList.remove('dcf-fade-in');
+    // Prevent this from being lazy loaded a second time.
+    image.classList.add('dcf-lazy-loaded');
+    image.classList.remove('dcf-lazy-load');
 
     if (src) {
       image.src = src;


### PR DESCRIPTION
- Remove `dcf-fade-in` and `dcf-faded-in` classes altogether. Scroll-based animations will be applied in a separate script.
- Remove `dcf-lazy-load` class after image is lazy-loaded