### PR TITLE
Display flexbox and grid items as blocks when printed

### DIFF
--- a/scss/print/_print.display.scss
+++ b/scss/print/_print.display.scss
@@ -3,4 +3,16 @@
 /////////////////////////
 
 
-.dcf-d-none\@print { @include d-none(!important); }
+// Hide when printed
+.dcf-d-none\@print {
+  @include d-none(!important);
+}
+
+
+// Display flexbox and grid items as blocks when printed
+.dcf-main .dcf-d-flex,
+.dcf-main .dcf-d-grid,
+.dcf-main [class*=' dcf-grid'],
+.dcf-main [class^='dcf-grid'] {
+  @include d-block(!important);
+}


### PR DESCRIPTION
Prevent content from being truncated when printing: https://stackoverflow.com/questions/45414152/css-flex-box-not-printing-all-pages-on-firefox