### PR TITLE
Rename node.js project to dcn-dcf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "dcf",
+  "name": "dcn-dcf",
   "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dcf",
+  "name": "dcn-dcf",
   "version": "2.0.0",
   "description": "Digital Campus Framework",
   "repository": {


### PR DESCRIPTION
NPM does not namespace packages by username or organization like both GitHub and Packagist do. Unfortunately, the 'dcf' namespace is already taken: https://www.npmjs.com/package/dcf.

This PR seeks to rename the node.js project to 'dcn-dcf'.

Upon merge, we'll want to update dcf_starter to pull from NPM instead of directly from GitHub.

