### PR TITLE
Add Sass logic for abbreviation border-bottom

### DIFF
--- a/scss/elements/_elements.abbreviations.scss
+++ b/scss/elements/_elements.abbreviations.scss
@@ -14,18 +14,23 @@ abbr {
 
 // Abbreviation title
 abbr[title] {
-  position: relative;
+  @if (to-number($border-bottom-width-abbr-title) != 0) {
+    position: relative;
+  }
   text-decoration: none;
 
-  &::after {
-    border-bottom: $border-bottom-width-abbr-title $border-bottom-style-abbr-title $border-bottom-color-abbr-title;
-    content: '';
-    height: 100%;
-    left: 0;
-    opacity: $opacity-abbr-title;
-    position: absolute;
-    top: 0;
-    width: 100%;
+  @if (to-number($border-bottom-width-abbr-title) != 0) {
+
+    &::after {
+      border-bottom: $border-bottom-width-abbr-title $border-bottom-style-abbr-title $border-bottom-color-abbr-title;
+      content: '';
+      height: 100%;
+      left: 0;
+      opacity: $opacity-abbr-title;
+      position: absolute;
+      top: 0;
+      width: 100%;
+    }
   }
 
 }

--- a/scss/elements/_elements.abbreviations.scss
+++ b/scss/elements/_elements.abbreviations.scss
@@ -20,7 +20,6 @@ abbr[title] {
   text-decoration: none;
 
   @if (to-number($border-bottom-width-abbr-title) != 0) {
-
     &::after {
       border-bottom: $border-bottom-width-abbr-title $border-bottom-style-abbr-title $border-bottom-color-abbr-title;
       content: '';
@@ -32,5 +31,4 @@ abbr[title] {
       width: 100%;
     }
   }
-
 }


### PR DESCRIPTION
Add logic to include `border-bottom` for `<abbr>` only if the `border-width` does not equal 0.