### PR TITLE
Proposed fix for responsive table mobile display

### DIFF
--- a/assets/dist/scss/components/_components.tables.scss
+++ b/assets/dist/scss/components/_components.tables.scss
@@ -99,15 +99,16 @@
   }
 
 
-  .dcf-table-responsive tr {
+  .dcf-table-responsive tr,
+  .dcf-table-responsive th {
     display: block;
   }
 
 
   .dcf-table-responsive td {
-    column-gap: $length-vw-1;
-    display: grid;
-    grid-template-columns: 1fr 2fr;
+    display: table;
+    border-collapse: separate;
+    width: 100%;
     text-align: left !important;
   }
 
@@ -143,10 +144,11 @@
   }
 
 
-  .dcf-table-responsive tbody td::before {
+  .dcf-table-responsive tbody td[data-label]::before {
     content: attr(data-label);
-    float: left;
     font-weight: bold;
+    display: table-cell;
+    width: 40%;
     @include pr-6;
   }
 


### PR DESCRIPTION
- Changed `display: grid` on`<td>` so links, spans, etc. inside wrap as expected
- Made `<th>` inside `<tbody>` `display: block;` so they go the full width of the table
- Made `data-label` only apply to cells that have that attribute