### PR TITLE
Fix DCF tabs hash redirect

### DIFF
--- a/js/dcf-tabs.js
+++ b/js/dcf-tabs.js
@@ -34,7 +34,7 @@ class DCFTabs {
 
     // set hash
     if (history.pushState) {
-      history.pushState(null, null, hash);
+      history.pushState(null, null, window.location.origin + window.location.pathname + hash);
     } else {
       location.hash = hash;
     }


### PR DESCRIPTION
Explicitly set URL in history.pushState call so hash redirect works in UNL CMS