### PR TITLE
Allow Touch Move for iOS modal scrolling

### DIFF
--- a/js/dcf-modal.js
+++ b/js/dcf-modal.js
@@ -148,7 +148,25 @@ class DCFModal {
 
     // Prevent body from scrolling
     if (this.disableBodyScroll) {
-      this.disableBodyScroll(thisModal);
+      this.disableBodyScroll(thisModal, {
+        allowTouchMove: (el) => {
+          let currentEl = el;
+          while (currentEl && currentEl !== document.body) {
+            if (currentEl.classList.contains('dcf-modal-content')) {
+              const iOSBodyStyle = {
+                WebkitOverflowScrolling: 'none',
+                overflow: 'hidden',
+              };
+              Object.assign(document.body.style, iOSBodyStyle);
+              return true;
+            }
+            if (currentEl.parentElement) {
+              currentEl = currentEl.parentElement;
+            }
+          }
+          return false;
+        },
+      });
     }
 
     // Add `.dcf-modal-is-open` helper class to body


### PR DESCRIPTION
Bug fix to allow modal scrolling on iOS touch devices.

I have a hacky test page available at https://go-test.unl.edu/modal.html