### PR TITLE
Revert select arrow fill color, add dark mode

### DIFF
--- a/scss/components/_components.forms-selects.scss
+++ b/scss/components/_components.forms-selects.scss
@@ -11,7 +11,7 @@
   @include txt-base; // Font size must be ≥16px to prevent iOS page zoom on focus
   appearance: none;
   background-color: var(--bg-select-2); // This is necessary for select options dropdown/popover in dark mode
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='var(--select)' d='M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z'/%3E%3C/svg%3E"), linear-gradient(var(--bg-select-1), var(--bg-select-2));
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='#{encodecolor($color-select-arrow-light-mode)}' d='M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z'/%3E%3C/svg%3E"), linear-gradient(var(--bg-select-1), var(--bg-select-2));
   background-position: right $bg-position-arrow top 50%, 0 0;
   background-repeat: no-repeat, repeat;
   background-size: $bg-size-arrow-select $bg-size-arrow-select, 100%;
@@ -28,6 +28,16 @@
   max-width: 100%;
   padding: $padding-top-input $padding-right-select $padding-bottom-input $padding-left-input;
   width: 100%;
+}
+
+
+@media (prefers-color-scheme: dark) {
+
+  .dcf-input-select, // TODO: deprecate .dcf-input-select?
+  .dcf-form select {
+    // Change select arrow color for dark mode
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='#{encodecolor($color-select-arrow-dark-mode)}' d='M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z'/%3E%3C/svg%3E"), linear-gradient(var(--bg-select-1), var(--bg-select-2));
+  }
 }
 
 


### PR DESCRIPTION
CSS custom properties (variables) aren’t rendered in SVG background-images. Use Sass variables instead.