### PR TITLE
DCF App support

### DIFF
--- a/js/dcf-navMenuToggle.js
+++ b/js/dcf-navMenuToggle.js
@@ -1,0 +1,167 @@
+class DCFNavMenuToggle {
+  constructor(bodyScrollLock) {
+    this.disableBodyScroll = bodyScrollLock.disableBodyScroll;
+    this.enableBodyScroll = bodyScrollLock.enableBodyScroll;
+
+    // grab an element
+    this.skipNav = document.getElementById('dcf-skip-nav');
+    this.institutionTitle = document.getElementById('dcf-institution-title');
+    this.logo = document.getElementById('dcf-logo-lockup');
+    this.nav = document.getElementById('dcf-navigation');
+    this.main = document.querySelector('main');
+    this.footer = document.getElementById('dcf-footer');
+
+    // construct an instance of Headroom, passing the element
+    const mobileActions = document.querySelectorAll('.hrjs');
+    Array.prototype.forEach.call(mobileActions, (action) => {
+      try {
+        const headroomObj = new Headroom(action, {
+          tolerance: {
+            up: 5,
+            down: 5
+          }
+        });
+        headroomObj.init();
+      } catch (err) {
+        // do nothing
+      }
+    });
+
+    this.toggleButtons = document.querySelectorAll('.dcf-nav-toggle-btn-menu');
+    this.toggleIconOpen = document.getElementById('dcf-nav-toggle-icon-open-menu');
+    this.toggleIconClose = document.getElementById('dcf-nav-toggle-icon-close-menu');
+    this.toggleLabel = document.querySelector('.dcf-nav-toggle-label-menu');
+    this.mobileNav = document.getElementById('dcf-navigation');
+    this.modalParent = document.querySelector('.dcf-nav-menu');
+    this.mobileNavMenu = document.getElementById('dcf-nav-menu-child');
+    if (!this.mobileNavMenu) {
+      this.mobileNavMenu = document.createElement('nav');
+      this.mobileNavMenu.setAttribute('id', 'dcf-nav-menu-child');
+    }
+    this.tabFocusEls = this.mobileNavMenu.querySelectorAll('[href]');
+    this.firstTabFocusEl = this.tabFocusEls[DCFUtility.magicNumbers('int0')];
+    this.lastTabFocusEl = this.tabFocusEls[this.tabFocusEls.length - DCFUtility.magicNumbers('int1')];
+    this.closeSearchEvent = new CustomEvent('closeSearch');
+    this.closeIDMOptionsEvent = new CustomEvent('closeDropDownWidget', { detail: { type: 'idm-logged-in' } });
+
+    // We need to keep track of the toggle button that activated the menu so that we can return focus to it when the menu is closed
+    this.activeToggleButton = null;
+
+    this.isNavigationOpen = () => this.modalParent.classList.contains('dcf-modal-open');
+
+    this.closeOpenNavigation = () => {
+      if (this.isNavigationOpen() === true) {
+        this.closeNavModal();
+      }
+    };
+
+    this.onKeyDown = (event) => {
+      if (event.keyCode === DCFUtility.magicNumbers('escCode')) {
+        this.closeNavModal();
+      }
+
+      const keycodeTab = 9;
+      const isTabPressed = event.key === 'Tab' || event.keyCode === keycodeTab;
+
+      if (!isTabPressed) {
+        return;
+      }
+
+      // Trap focus inside the nav modal
+      if (event.key === 'Tab' || event.keyCode === keycodeTab) {
+        if (event.shiftKey) {
+          // Tab backwards (shift + tab)
+          if (document.activeElement === this.firstTabFocusEl) {
+            event.preventDefault();
+            this.lastTabFocusEl.focus();
+          }
+        } else if (document.activeElement === this.lastTabFocusEl) {
+          event.preventDefault();
+          this.firstTabFocusEl.focus();
+        }
+      }
+    };
+
+    // add an event listener for close Navigation Event
+    document.addEventListener('closeNavigation', this.closeOpenNavigation, false);
+
+    // add an event listener for resize
+    window.addEventListener('resize', this.closeOpenNavigation, false);
+
+    Array.prototype.forEach.call(this.toggleButtons, (button) => {
+      button.addEventListener('click', (clickEvent) => {
+        this.activeToggleButton = clickEvent.currentTarget;
+        if (this.isNavigationOpen() === true) {
+          this.closeNavModal();
+        } else {
+          this.openNavModal();
+        }
+        return false;
+      }, false);
+    });
+
+    const primaryNavLi = document.querySelectorAll('.dcf-nav-menu-child>ul>li');
+    const allPrimaryNavLi = Array.from(primaryNavLi);
+    // Find any child <ul> in local navigation <li>
+    const hasChild = allPrimaryNavLi.find((el) => el.querySelector('ul'));
+    const desktopBtn = document.getElementById('dcf-menu-toggle');
+
+    // Show "desktop" menu toggle button if navigation contains children
+    if (hasChild && desktopBtn) {
+      desktopBtn.removeAttribute('hidden');
+      desktopBtn.setAttribute('aria-expanded', 'false');
+      desktopBtn.setAttribute('aria-label', 'open menu');
+    }
+  }
+
+  openNavModal() {
+    // Hide other mobile toggles
+    document.dispatchEvent(this.closeSearchEvent);
+    document.dispatchEvent(this.closeIDMOptionsEvent);
+
+    if (window.matchMedia('(max-width: 56.12em)').matches) {
+      this.skipNav.setAttribute('aria-hidden', 'true');
+      this.institutionTitle.setAttribute('aria-hidden', 'true');
+      this.logo.setAttribute('aria-hidden', 'true');
+      this.nav.setAttribute('aria-hidden', 'false');
+      this.main.setAttribute('aria-hidden', 'true');
+      this.footer.setAttribute('aria-hidden', 'true');
+      this.disableBodyScroll(this.mobileNavMenu);
+    }
+    Array.prototype.forEach.call(this.toggleButtons, (button) => {
+      button.setAttribute('aria-expanded', 'true');
+      button.setAttribute('aria-label', 'close menu');
+    });
+    this.modalParent.classList.add('dcf-modal-open');
+    this.toggleIconOpen.classList.add('dcf-d-none');
+    this.toggleIconClose.classList.remove('dcf-d-none');
+    this.toggleLabel.textContent = 'Close';
+
+    this.firstTabFocusEl.focus();
+    document.addEventListener('keydown', this.onKeyDown);
+  }
+
+  closeNavModal() {
+    if (window.matchMedia('(max-width: 56.12em)').matches) {
+      this.skipNav.setAttribute('aria-hidden', 'false');
+      this.institutionTitle.setAttribute('aria-hidden', 'false');
+      this.logo.setAttribute('aria-hidden', 'false');
+      this.nav.setAttribute('aria-hidden', 'true');
+      this.main.setAttribute('aria-hidden', 'false');
+      this.footer.setAttribute('aria-hidden', 'false');
+
+      // Allow body scroll when navigation is closed
+      this.enableBodyScroll(this.mobileNavMenu);
+    }
+    Array.prototype.forEach.call(this.toggleButtons, (button) => {
+      button.setAttribute('aria-expanded', 'false');
+      button.setAttribute('aria-label', 'open menu');
+    });
+    this.modalParent.classList.remove('dcf-modal-open');
+    this.toggleIconOpen.classList.remove('dcf-d-none');
+    this.toggleIconClose.classList.add('dcf-d-none');
+    this.toggleLabel.textContent = 'Menu';
+    this.activeToggleButton.focus();
+    document.removeEventListener('keydown', this.onKeyDown);
+  }
+}

--- a/scss/components/_components.app.scss
+++ b/scss/components/_components.app.scss
@@ -4,7 +4,7 @@
 
 @include mq(md, max, width) {
 
-  .unl.app .dcf-app-controls ul:not(:last-child) {
+  .app .dcf-app-controls ul:not(:last-child) {
     flex-direction: column;
   }
 
@@ -12,18 +12,98 @@
 
 @include mq(md, min, width) {
 
-  .unl.app .dcf-app-controls {
+  .app .dcf-app-controls {
     display: flex;
     justify-content: space-between;
   }
 
-  .unl.app .dcf-app-controls ul:not(:last-child) {
-    border-left: 1px solid inherit;
+  .app .dcf-app-controls ul:not(:last-child) {
+    border-left: 1px solid var(--app-control-border-color, $default-app-control-border-color);
     display: flex;
   }
 
-  .unl.app .dcf-app-controls li {
-    border-right: 1px solid inherit;
+  .app .dcf-app-controls li {
+    border-right: 1px solid var(--app-control-border-color, $default-app-control-border-color);
+  }
+
+}
+
+@include mq(md, max, width) {
+
+  .dcf-nav-menu {
+    bottom: #{ms(10)}em;
+    height: 100vh;
+    opacity: 0;
+    pointer-events: none;
+    position: fixed;
+    transition: opacity $transition-duration-fade-in $transition-timing-fn-fade-in, visibility 0ms .4s;
+    visibility: hidden;
+    width: 100%;
+    z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
+  }
+
+  // Open when parent model is open
+  .dcf-nav-menu.dcf-modal-open {
+    opacity: 1;
+    pointer-events: auto;
+    transition: opacity $transition-duration-fade-in $transition-timing-fn-fade-in;
+    visibility: visible;
+  }
+
+  .dcf-nav-menu-child {
+    @include overflow-y-auto;
+    bottom: #{ms(10)}em;
+    height: 43vh;
+    padding-left: $length-vw-2;
+    padding-right: $length-vw-2;
+    position: fixed;
+  }
+
+  .dcf-nav-menu-child > *:first-child {
+    @include mt-6;
+  }
+
+  .dcf-nav-menu-child > *:last-child {
+    @include mb-7;
+  }
+
+  .dcf-nav-menu-child::before,
+  .dcf-nav-menu-child::after {
+    content: '';
+    height: #{ms(6)}em;
+    left: 0;
+    position: fixed;
+    width: 100%;
+    z-index: 999;
+  }
+
+  .dcf-nav-menu a,
+  .dcf-nav-menu button {
+    margin-left: -#{ms(0)}rem;
+  }
+
+  .dcf-nav-menu ul ul {
+    @include txt-xs;
+  }
+
+}
+
+@include mq(md, min, width) {
+
+  .dcf-nav-menu {
+    display: flex;
+    flex-wrap: nowrap;
+    padding-left: $length-vw-2;
+    padding-right: $length-vw-2;
+  }
+
+  .dcf-nav-menu ul ul {
+    @include txt-sm;
+  }
+
+  .dcf-nav-menu a,
+  .dcf-nav-menu button {
+    @include txt-xs;
   }
 
 }

--- a/scss/components/_components.app.scss
+++ b/scss/components/_components.app.scss
@@ -1,0 +1,29 @@
+///////////////////////////
+// CORE / COMPONENTS / APP
+///////////////////////////
+
+@include mq(md, max, width) {
+
+  .unl.app .dcf-app-controls ul:not(:last-child) {
+    flex-direction: column;
+  }
+
+}
+
+@include mq(md, min, width) {
+
+  .unl.app .dcf-app-controls {
+    display: flex;
+    justify-content: space-between;
+  }
+
+  .unl.app .dcf-app-controls ul:not(:last-child) {
+    border-left: 1px solid inherit;
+    display: flex;
+  }
+
+  .unl.app .dcf-app-controls li {
+    border-right: 1px solid inherit;
+  }
+
+}

--- a/scss/components/_components.forms.scss
+++ b/scss/components/_components.forms.scss
@@ -76,8 +76,8 @@
 .dcf-input-text, // TODO: deprecate .dcf-input-text?
 .dcf-form input:not([type="file"]):not([type="submit"]),
 .dcf-form textarea {
-  background-color: var(--bg-input);
-  border: $border-width-input $border-style-input var(--b-input);
+  background-color: var(--bg-input, $default-bg-input);
+  border: $border-width-input $border-style-input var(--b-input, $default-b-input);
   @if ($border-radius-input-roundrect) {
     border-radius: $roundrect;
   } @else {

--- a/scss/components/_components.nav-menu.scss
+++ b/scss/components/_components.nav-menu.scss
@@ -9,3 +9,101 @@
   margin-bottom: 0;
   padding-left: 0;
 }
+
+.dcf-nav-menu li {
+  margin-bottom: 0;
+}
+
+.dcf-nav-menu-child a,
+.dcf-nav-menu-child button {
+  @include lh-3;
+  display: block;
+  padding: #{ms(0)}em #{ms(0)}rem;
+}
+
+@include mq(md, max, width) {
+
+  .dcf-nav-menu {
+    background-color: var(--nav-menu-bg-color, $default-nav-menu-bg-color);
+    bottom: #{ms(10)}em;
+    height: 100vh;
+    opacity: 0;
+    pointer-events: none;
+    position: fixed;
+    transition: opacity $transition-duration-fade-in $transition-timing-fn-fade-in, visibility 0ms .4s;
+    visibility: hidden;
+    width: 100%;
+    z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
+  }
+
+  // Open when parent model is open
+  .dcf-nav-menu.dcf-modal-open {
+    opacity: 1;
+    pointer-events: auto;
+    transition: opacity $transition-duration-fade-in $transition-timing-fn-fade-in;
+    visibility: visible;
+  }
+
+
+  .dcf-nav-menu-child {
+    //@include bg-scarlet;
+    @include overflow-y-auto;
+    bottom: #{ms(10)}em;
+    height: 43vh;
+    padding-left: $length-vw-2;
+    padding-right: $length-vw-2;
+    position: fixed;
+  }
+
+  .dcf-nav-menu-child > *:first-child {
+    @include mt-6;
+  }
+
+  .dcf-nav-menu-child > *:last-child {
+    @include mb-7;
+  }
+
+  .dcf-nav-menu-child::before,
+  .dcf-nav-menu-child::after {
+    content: '';
+    height: #{ms(6)}em;
+    left: 0;
+    position: fixed;
+    width: 100%;
+    z-index: 999;
+  }
+
+  .dcf-nav-menu a,
+  .dcf-nav-menu button {
+    margin-left: -#{ms(0)}rem;
+  }
+
+
+  .dcf-nav-menu ul ul {
+    @include txt-xs;
+  }
+
+}
+
+@include mq(md, min, width) {
+
+  .dcf-nav-menu {
+    //@include bg-scarlet;
+    display: flex;
+    flex-wrap: nowrap;
+    padding-left: $length-vw-2;
+    padding-right: $length-vw-2;
+  }
+
+
+  .dcf-nav-menu ul ul {
+    @include txt-sm;
+  }
+
+
+  .dcf-nav-menu a,
+  .dcf-nav-menu button {
+    @include txt-xs;
+  }
+
+}

--- a/scss/components/_components.nav-toggle.scss
+++ b/scss/components/_components.nav-toggle.scss
@@ -1,0 +1,78 @@
+///////////////////////////////////
+// CORE / COMPONENTS / NAV: TOGGLE
+///////////////////////////////////
+
+
+.dcf-nav-toggle-btn {
+  appearance: none;
+}
+
+@include mq(md, max, width) {
+
+  .dcf-nav-toggle-group {
+    background-color: var(--bg-nav-toggle-group, $default-bg-nav-toggle-group);
+    display: flex;
+    z-index: $z-nav-toggle-group;
+
+    // Browsers which partially support CSS Environment variables (iOS 11.0-11.2)
+    @supports (padding-bottom: constant(safe-area-inset-bottom)) {
+      --safe-area-inset-bottom: constant(safe-area-inset-bottom);
+      padding-bottom: var(--safe-area-inset-bottom);
+    }
+
+    // Browsers which fully support CSS Environment variables (iOS 11.2+)
+    @supports (padding-bottom: env(safe-area-inset-bottom)) {
+      --safe-area-inset-bottom: env(safe-area-inset-bottom);
+      padding-bottom: var(--safe-area-inset-bottom);
+    }
+  }
+
+
+  .dcf-nav-toggle-btn {
+    flex-basis: 25%;
+  }
+
+
+  .dcf-nav-menu .dcf-nav-toggle-btn-menu {
+    display: none;
+  }
+
+  .headroom {
+    transition: transform 250ms ease-out !important;
+    will-change: transform;
+  }
+
+  //   .headroom--fixed {
+  //   	position: -webkit-fixed;
+  //   	position: fixed;
+  //   	z-index: 10;
+  //   	right: 0;
+  //   	left: 0;
+  //   	bottom: 0vh;
+  //   }
+
+
+  .headroom--pinned {
+    transform: translateY(0%);
+  }
+
+
+  .headroom--unpinned {
+    transform: translateY(100%);
+  }
+
+}
+
+
+@include mq(md, min, width) {
+
+  .dcf-nav-toggle-group {
+    display: none;
+  }
+
+
+  .dcf-nav-menu .dcf-nav-toggle-btn-menu {
+    display: flex;
+  }
+
+}

--- a/scss/mixins/_mixins.backgrounds.scss
+++ b/scss/mixins/_mixins.backgrounds.scss
@@ -5,7 +5,7 @@
 
 // Color
 @mixin bg-transparent($imp:null) { background-color: transparent $imp; }
-@mixin bg-white($imp:null) { background-color: var(--bg-white) $imp; }
+@mixin bg-white($imp:null) { background-color: var(--bg-white, $default-bg-white) $imp; }
 @mixin bg-overlay-dark($imp:null) { background-color: var(--bg-overlay-dark) $imp; }
 @mixin bg-overlay-light($imp:null) { background-color: var(--bg-overlay-light) $imp; }
 

--- a/scss/mixins/_mixins.backgrounds.scss
+++ b/scss/mixins/_mixins.backgrounds.scss
@@ -6,8 +6,8 @@
 // Color
 @mixin bg-transparent($imp:null) { background-color: transparent $imp; }
 @mixin bg-white($imp:null) { background-color: var(--bg-white, $default-bg-white) $imp; }
-@mixin bg-overlay-dark($imp:null) { background-color: var(--bg-overlay-dark) $imp; }
-@mixin bg-overlay-light($imp:null) { background-color: var(--bg-overlay-light) $imp; }
+@mixin bg-overlay-dark($imp:null) { background-color: var(--bg-overlay-dark, $default-bg-overlay-dark) $imp; }
+@mixin bg-overlay-light($imp:null) { background-color: var(--bg-overlay-light, $default-bg-overlay-light) $imp; }
 
 
 // Position

--- a/scss/variables/_variables.tmp-defaults.scss
+++ b/scss/variables/_variables.tmp-defaults.scss
@@ -3,6 +3,8 @@
 ////////////////////////////////////
 
 $default-bg-white: #fff;
+$default-bg-overlay-dark: fade-out(#000, .06); ;
+$default-bg-overlay-light: fade-out(#fefdfa, .06);
 $default-app-control-border-color: #000;
-$default-nav-menu-bg-color: #eee;
+$default-nav-menu-bg-color: #fefdfa;
 $default-bg-nav-toggle-group: #fff;

--- a/scss/variables/_variables.tmp-defaults.scss
+++ b/scss/variables/_variables.tmp-defaults.scss
@@ -9,5 +9,5 @@ $default-app-control-border-color: #000;
 $default-nav-menu-bg-color: #fefdfa;
 $default-bg-nav-toggle-group: #fff;
 
-$default-bg-input: #000;
-$default-b-input: #6b6b68;
+$default-bg-input: #fff;
+$default-b-input: #c7c8ca;

--- a/scss/variables/_variables.tmp-defaults.scss
+++ b/scss/variables/_variables.tmp-defaults.scss
@@ -8,3 +8,6 @@ $default-bg-overlay-light: fade-out(#fefdfa, .06);
 $default-app-control-border-color: #000;
 $default-nav-menu-bg-color: #fefdfa;
 $default-bg-nav-toggle-group: #fff;
+
+$default-bg-input: #000;
+$default-b-input: #6b6b68;

--- a/scss/variables/_variables.tmp-defaults.scss
+++ b/scss/variables/_variables.tmp-defaults.scss
@@ -1,0 +1,8 @@
+////////////////////////////////////
+// THEME / VARIABLES / DEFAULTS
+////////////////////////////////////
+
+$default-bg-white: #fff;
+$default-app-control-border-color: #000;
+$default-nav-menu-bg-color: #eee;
+$default-bg-nav-toggle-group: #fff;


### PR DESCRIPTION
This and the related DCF Starter serve as a sample of what needs to be done to get DCF and starter to a usable state.  **Full theming** will need to be done in starter at a minimum at sometime but some core theming at the base DCF level **may be** needed or desired.  I'm not sure the best way to do it.   This PR samples some core theming. The structure used is not intended as final solution but just a simple/general example.

The public information in their current state will need the nav toggle functionality to support mobile navigation and/or app controls.  I ported the javascript needed to base DCF with `dcf-navMenuToggle.js`.  This is the only change in PR which must be done.  Once part of DCF, WDN can be updated to use.

Related DCF Starter PR: https://github.com/digitalcampusframework/dcf_starter/pull/43

The DCF Starter implements changes needed to pull default variables in from core and adds a app.html as a sample application page to test nav toggle and other common application markup.  This sample page is a very rough draft and only serves as a starting point.
