### PR TITLE
Fix issues with DCFTabs

### DIFF
--- a/js/dcf-tabs.js
+++ b/js/dcf-tabs.js
@@ -218,23 +218,26 @@ class DCFTabs {
       // Initially activate the first tab and reveal the first tab panel
       this.switchTab(null, tabs[DCFUtility.magicNumbers('int0')], false);
 
-      tabList.addEventListener('resetTabGroup', () => {
-        const newTab = tabs[DCFUtility.magicNumbers('int0')];
-        const oldTab = this.getCurrentTabByTab(newTab);
-        if (oldTab !== newTab) {
-          this.switchTab(oldTab, newTab, false);
-        }
-      });
+      if (this.useHashChange) {
+        // Handle resetTabGroup on tabList
+        tabList.addEventListener('resetTabGroup', () => {
+          const newTab = tabs[DCFUtility.magicNumbers('int0')];
+          const oldTab = this.getCurrentTabByTab(newTab);
+          if (oldTab !== newTab) {
+            this.switchTab(oldTab, newTab, false);
+          }
+        });
 
-      // Handle hash change
-      window.addEventListener('hashchange', () => {
-        const hash = window.location.hash;
-        if (hash) {
-          this.displayTabByHash(hash);
-        } else {
-          tabList.dispatchEvent(new Event('resetTabGroup'));
-        }
-      });
+        // Handle hash change
+        window.addEventListener('hashchange', () => {
+          const hash = window.location.hash;
+          if (hash) {
+            this.displayTabByHash(hash);
+          } else {
+            tabList.dispatchEvent(new Event('resetTabGroup'));
+          }
+        });
+      }
     });
 
     // Open tab on page load if valid

--- a/js/dcf-tabs.js
+++ b/js/dcf-tabs.js
@@ -22,15 +22,12 @@ class DCFTabs {
           hidePanel.hidden = true;
         }
       }
+
+      // Focus on new tab
+      newTab.focus();
+      newTab.setAttribute('tabindex', '0');
+      newTab.setAttribute('aria-selected', 'true');
     }
-
-    newTab.focus();
-    // Make the active tab focusable by the user (Tab key)
-    newTab.removeAttribute('tabindex');
-    // Set the selected state
-    newTab.setAttribute('aria-selected', 'true');
-    newTab.setAttribute('tabindex', '0');
-
 
     // show panel for newTab
     const showPanelID = newTab.getAttribute('data-panel-id');
@@ -115,7 +112,13 @@ class DCFTabs {
         tab.setAttribute('role', 'tab');
 
         // Add tabindex to each tab
-        tab.setAttribute('tabindex', '-1');
+        if (tabIndex === DCFUtility.magicNumbers('int0')) {
+          tab.setAttribute('tabindex', '0');
+          tab.setAttribute('aria-selected', 'true');
+        } else {
+          tab.setAttribute('tabindex', '-1');
+          tab.removeAttribute('aria-selected');
+        }
 
         // Add class to each tab's parent (list item)
         tab.parentNode.classList.add('dcf-tabs-list-item', 'dcf-mb-0');
@@ -215,23 +218,23 @@ class DCFTabs {
       // Initially activate the first tab and reveal the first tab panel
       this.switchTab(null, tabs[DCFUtility.magicNumbers('int0')], false);
 
-      window.addEventListener('resetTabGroup', () => {
+      tabList.addEventListener('resetTabGroup', () => {
         const newTab = tabs[DCFUtility.magicNumbers('int0')];
         const oldTab = this.getCurrentTabByTab(newTab);
         if (oldTab !== newTab) {
           this.switchTab(oldTab, newTab, false);
         }
       });
-    });
 
-    // Handle hash change
-    window.addEventListener('hashchange', () => {
-      const hash = window.location.hash;
-      if (hash) {
-        this.displayTabByHash(hash);
-      } else {
-        window.dispatchEvent(new Event('resetTabGroup'));
-      }
+      // Handle hash change
+      window.addEventListener('hashchange', () => {
+        const hash = window.location.hash;
+        if (hash) {
+          this.displayTabByHash(hash);
+        } else {
+          tabList.dispatchEvent(new Event('resetTabGroup'));
+        }
+      });
     });
 
     // Open tab on page load if valid

--- a/js/dcf-tabs.js
+++ b/js/dcf-tabs.js
@@ -1,3 +1,25 @@
+let dcfTabsObjects = [];
+/* eslint func-style: ["error", "declaration", { "allowArrowFunctions": true }] */
+const handleDCFTabsHashChange = () => {
+  let resetTabGroupIDsProcessed = [];
+  Array.prototype.forEach.call(dcfTabsObjects, (dcfTabsObject) => {
+    const hash = window.location.hash;
+    if (hash) {
+      dcfTabsObject.displayTabByHash(hash);
+    } else {
+      Array.prototype.forEach.call(dcfTabsObject.tabGroups, (tabGroup) => {
+        const tabGroupID = tabGroup.getAttribute('id');
+        if (!resetTabGroupIDsProcessed.includes(tabGroupID)) {
+          resetTabGroupIDsProcessed.push(tabGroupID);
+          const tabList = tabGroup.querySelector('.dcf-tabs > ol, .dcf-tabs > ul');
+          tabList.dispatchEvent(new Event('resetTabGroup'));
+        }
+      });
+    }
+  });
+};
+window.addEventListener('hashchange', handleDCFTabsHashChange);
+
 class DCFTabs {
   constructor(tabGroups, options = {}) {
     this.tabGroups = tabGroups;
@@ -6,6 +28,7 @@ class DCFTabs {
     if (options.useHashChange === false) {
       this.useHashChange = false;
     }
+    dcfTabsObjects.push(this);
   }
 
   // Tab switching function
@@ -24,9 +47,7 @@ class DCFTabs {
       }
 
       // Focus on new tab
-      newTab.focus();
-      newTab.setAttribute('tabindex', '0');
-      newTab.setAttribute('aria-selected', 'true');
+      this.focusTab(newTab);
     }
 
     // show panel for newTab
@@ -50,6 +71,12 @@ class DCFTabs {
       // Set page hash
       this.setPageHash(newTab.getAttribute('href'));
     }
+  }
+
+  focusTab(tab) {
+    tab.focus();
+    tab.setAttribute('tabindex', '0');
+    tab.setAttribute('aria-selected', 'true');
   }
 
   getCurrentTabByTab(tab) {
@@ -83,6 +110,8 @@ class DCFTabs {
         const oldTab = this.getCurrentTabByTab(newTab);
         if (oldTab !== newTab) {
           this.switchTab(oldTab, newTab, false);
+        } else {
+          this.focusTab(newTab);
         }
       }
     }
@@ -225,16 +254,6 @@ class DCFTabs {
           const oldTab = this.getCurrentTabByTab(newTab);
           if (oldTab !== newTab) {
             this.switchTab(oldTab, newTab, false);
-          }
-        });
-
-        // Handle hash change
-        window.addEventListener('hashchange', () => {
-          const hash = window.location.hash;
-          if (hash) {
-            this.displayTabByHash(hash);
-          } else {
-            tabList.dispatchEvent(new Event('resetTabGroup'));
           }
         });
       }

--- a/js/dcf-utility.js
+++ b/js/dcf-utility.js
@@ -18,7 +18,8 @@ class DCFUtility {
       hex0x3: 0x3,
       hex0x8: 0x8,
 
-      // Keycodes
+      // Keycodes (Leave for backwards compatibility)
+      tabCode: 9,
       escCode: 27,
       spaceKeyCode: 32,
       arrowLeftCode: 37,
@@ -29,6 +30,29 @@ class DCFUtility {
     Object.freeze(magicNumbers);
 
     return magicNumber in magicNumbers ? magicNumbers[magicNumber] : undefined;
+  }
+
+  static keyEvents(keyEvent) {
+    const keyEvents = {
+      arrowDown: { code: 'ArrowDown', key: 'ArrowDown', keyCode: 40 },
+      arrowLeft: { code: 'ArrowLeft', key: 'ArrowLeft', keyCode: 37 },
+      arrowRight: { code: 'ArrowRight', key: 'ArrowRight', keyCode: 39 },
+      arrowUp: { code: 'ArrowUp', key: 'ArrowUp', keyCode: 38 },
+      escape: { code: 'Escape', key: 'Escape', keyCode: 27 },
+      keyC: { code: 'KeyC', key: 'c', keyCode: 67 },
+      space: { code: 'Space', key: ' ', keyCode: 32 },
+      tab: { code: 'Tab', key: 'Tab', keyCode: 9 }
+    };
+    Object.freeze(keyEvents);
+
+    return keyEvent in keyEvents ? keyEvents[keyEvent] : undefined;
+  }
+
+  static isKeyEvent(event, checkEvent) {
+    const validKey = event.key && event.key === checkEvent.key && event.key === checkEvent.key;
+    const validCode = event.code && checkEvent.code && event.code === checkEvent.code;
+    const validKeyCode = event.keyCode && checkEvent.keyCode && event.keyCode === checkEvent.keyCode;
+    return validKey || validCode || validKeyCode;
   }
 
   static uuidv4() {
@@ -42,6 +66,18 @@ class DCFUtility {
         uuidv4 = uuid === 'x' ? rand : rand & HEX0x3 | HEX0x8;
       return uuidv4.toString(NUMERIC_16);
     });
+  }
+
+  static checkSetElementId(element, id = null) {
+    let elementId = element.getAttribute('id');
+    if (!elementId) {
+      if (id) {
+        elementId = id;
+      } else {
+        elementId = DCFUtility.uuidv4();
+      }
+    }
+    return elementId;
   }
 
   static testWebp(callback) {


### PR DESCRIPTION
Issues addressed:

* Associate tab panels (sections) by tab DOM id and not by order in markup
* Allow nested tabs.
* Better support history (back/forward) to display correct tab and panel.
* Add option to allow opt out of hashChange
* Allow dev to define ids for tab groups and/or tabs.
* Implement new key event checking not move away from deprecated keyboardEvent.which check.
* Move `hashchange` event list outside of DCFTabs class to prevent multiple listeners.

Can be tested by using this DCF Starter PR: https://github.com/digitalcampusframework/dcf_starter/pull/47
