### PR TITLE
Increase specificity in blockquote paragraphs

### DIFF
--- a/scss/components/_components.blockquotes.scss
+++ b/scss/components/_components.blockquotes.scss
@@ -17,13 +17,13 @@
 }
 
 
-.dcf-blockquote p {
+.dcf-blockquote > p {
   font-size: $font-size-blockquote-p;
   padding-top: $padding-top-blockquote-p;
 }
 
 
-.dcf-blockquote p::after {
+.dcf-blockquote > p::after {
   content: close-quote;
 }
 


### PR DESCRIPTION
Specify styles for direct child paragraph to avoid applying styles to paragraphs that may be contained inside the blockquote’s attribution (`<footer>`).