### PR TITLE
Use CSS variable for form required label color

### DIFF
--- a/scss/components/_components.forms.scss
+++ b/scss/components/_components.forms.scss
@@ -53,7 +53,7 @@
 
 // Required
 .dcf-required {
-  color: $color-required-label-light-mode;
+  color: var(--form-required);
   font-size: $font-size-required;
   @if ($font-style-required-italic) {
     font-style: italic;


### PR DESCRIPTION
Sass variable was hard-coded as the light mode required label color. There was no way to activate the dark mode color without writing custom CSS.