### PR TITLE
Replace CSS variables with Sass variables

### DIFF
--- a/scss/components/_components.app.scss
+++ b/scss/components/_components.app.scss
@@ -2,6 +2,7 @@
 // CORE / COMPONENTS / APP
 ///////////////////////////
 
+
 @include mq(md, max, width) {
 
   .app .dcf-app-controls ul:not(:last-child) {
@@ -10,6 +11,7 @@
 
 }
 
+
 @include mq(md, min, width) {
 
   .app .dcf-app-controls {
@@ -17,16 +19,19 @@
     justify-content: space-between;
   }
 
+
   .app .dcf-app-controls ul:not(:last-child) {
-    border-left: 1px solid var(--app-control-border-color, $default-app-control-border-color);
+    border-left: 1px solid $border-color-app-control;
     display: flex;
   }
 
+
   .app .dcf-app-controls li {
-    border-right: 1px solid var(--app-control-border-color, $default-app-control-border-color);
+    border-right: 1px solid $border-color-app-control;
   }
 
 }
+
 
 @include mq(md, max, width) {
 
@@ -42,6 +47,7 @@
     z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
 
+
   // Open when parent model is open
   .dcf-nav-menu.dcf-modal-open {
     opacity: 1;
@@ -49,6 +55,7 @@
     transition: opacity $transition-duration-fade-in $transition-timing-fn-fade-in;
     visibility: visible;
   }
+
 
   .dcf-nav-menu-child {
     @include overflow-y-auto;
@@ -59,13 +66,16 @@
     position: fixed;
   }
 
+
   .dcf-nav-menu-child > *:first-child {
     @include mt-6;
   }
 
+
   .dcf-nav-menu-child > *:last-child {
     @include mb-7;
   }
+
 
   .dcf-nav-menu-child::before,
   .dcf-nav-menu-child::after {
@@ -77,16 +87,19 @@
     z-index: 999;
   }
 
+
   .dcf-nav-menu a,
   .dcf-nav-menu button {
     margin-left: -#{ms(0)}rem;
   }
+
 
   .dcf-nav-menu ul ul {
     @include txt-xs;
   }
 
 }
+
 
 @include mq(md, min, width) {
 
@@ -97,9 +110,11 @@
     padding-right: $length-vw-2;
   }
 
+
   .dcf-nav-menu ul ul {
     @include txt-sm;
   }
+
 
   .dcf-nav-menu a,
   .dcf-nav-menu button {

--- a/scss/components/_components.badges.scss
+++ b/scss/components/_components.badges.scss
@@ -6,8 +6,8 @@
 // Default badges
 .dcf-badge {
   @include lh-1;
-  background-color: var(--bg-badge);
-  color: var(--badge);
+  background-color: $bg-color-badge;
+  color: $color-badge;
   display: inline-block;
   font-size: $font-size-badge;
   padding: $padding-top-badge $padding-right-badge $padding-bottom-badge $padding-left-badge;

--- a/scss/components/_components.breadcrumbs.scss
+++ b/scss/components/_components.breadcrumbs.scss
@@ -10,16 +10,16 @@
 
 
 .dcf-breadcrumbs li:not(:last-child) {
-  margin-right: $breadcrumb-spacing;
+  margin-right: $margin-breadcrumbs;
 }
 
 
 .dcf-breadcrumbs li:not(:last-child)::after {
-  border-bottom: $breadcrumb-arrow-size solid transparent;
-  border-left: $breadcrumb-arrow-size solid $border-color-breadcrumb-arrow;
-  border-top: $breadcrumb-arrow-size solid transparent;
+  border-bottom: $border-width-breadcrumb-arrow solid transparent;
+  border-left: $border-width-breadcrumb-arrow solid $border-color-breadcrumb-arrow;
+  border-top: $border-width-breadcrumb-arrow solid transparent;
   content: '';
   height: 0;
-  margin-left: $breadcrumb-spacing;
+  margin-left: $margin-breadcrumbs;
   width: 0;
 }

--- a/scss/components/_components.breadcrumbs.scss
+++ b/scss/components/_components.breadcrumbs.scss
@@ -16,7 +16,7 @@
 
 .dcf-breadcrumbs li:not(:last-child)::after {
   border-bottom: $breadcrumb-arrow-size solid transparent;
-  border-left: $breadcrumb-arrow-size solid var(--b-breadcrumb-arrow);
+  border-left: $breadcrumb-arrow-size solid $border-color-breadcrumb-arrow;
   border-top: $breadcrumb-arrow-size solid transparent;
   content: '';
   height: 0;

--- a/scss/components/_components.button-groups.scss
+++ b/scss/components/_components.button-groups.scss
@@ -16,13 +16,13 @@
 
 .dcf-btn-group li:not(:first-child) .dcf-btn-primary,
 .dcf-btn-group .dcf-btn-primary + .dcf-btn-primary {
-  margin-left: $spacing-button-group; // Provide spacing in between button group buttons
+  margin-left: $margin-button-group; // Provide spacing in between button group buttons
 }
 
 
 .dcf-btn-group li:not(:first-child) .dcf-btn-secondary,
 .dcf-btn-group .dcf-btn-secondary + .dcf-btn-secondary {
-  margin-left: -$spacing-button-group; // Collapse internal shared borders
+  margin-left: -$margin-button-group; // Collapse internal shared borders
 }
 
 

--- a/scss/components/_components.buttons.scss
+++ b/scss/components/_components.buttons.scss
@@ -37,49 +37,49 @@ a.dcf-btn-inverse-secondary {
 
 .dcf-btn-primary,
 .dcf-btn-primary:link {
-  background-color: var(--bg-btn-primary);
-  border-color: var(--b-btn-primary);
-  color: var(--btn-primary);
+  background-color: $bg-color-button-primary;
+  border-color: $border-color-button-primary;
+  color: $color-button-primary;
 }
 
 
 .dcf-btn-secondary,
 .dcf-btn-secondary:link {
-  background-color: var(--bg-btn-secondary);
-  border-color: var(--b-btn-secondary);
-  color: var(--btn-secondary);
+  background-color: $bg-color-button-secondary;
+  border-color: $border-color-button-secondary;
+  color: $color-button-secondary;
 }
 
 
 .dcf-btn-tertiary,
 .dcf-btn-tertiary:link {
-  background-color: var(--bg-btn-tertiary);
-  border-color: var(--b-btn-tertiary);
-  color: var(--btn-tertiary);
+  background-color: $bg-color-button-tertiary;
+  border-color: $border-color-button-tertiary;
+  color: $color-button-tertiary;
 }
 
 
 .dcf-btn-inverse-primary,
 .dcf-btn-inverse-primary:link {
-  background-color: var(--bg-btn-inverse-primary);
-  border-color: var(--b-btn-inverse-primary);
-  color: var(--btn-inverse-primary);
+  background-color: $bg-color-button-inverse-primary;
+  border-color: $border-color-button-inverse-primary;
+  color: $color-button-inverse-primary;
 }
 
 
 .dcf-btn-inverse-secondary,
 .dcf-btn-inverse-secondary:link {
-  background-color: var(--bg-btn-inverse-secondary);
-  border-color: var(--b-btn-inverse-secondary);
-  color: var(--btn-inverse-secondary);
+  background-color: $bg-color-button-inverse-secondary;
+  border-color: $border-color-button-inverse-secondary;
+  color: $color-button-inverse-secondary;
 }
 
 
 .dcf-btn-inverse-tertiary,
 .dcf-btn-inverse-tertiary:link {
-  background-color: var(--bg-btn-inverse-tertiary);
-  border-color: var(--b-btn-inverse-tertiary);
-  color: var(--btn-inverse-tertiary);
+  background-color: $bg-color-button-inverse-tertiary;
+  border-color: $border-color-button-inverse-tertiary;
+  color: $color-button-inverse-tertiary;
   text-decoration: underline;
 }
 

--- a/scss/components/_components.cards.scss
+++ b/scss/components/_components.cards.scss
@@ -5,7 +5,7 @@
 
 // Individual card
 .dcf-card {
-  background-color: var(--bg-card);
+  background-color: $bg-color-card;
   font-size: $font-size-card;
   margin-bottom: 0;
 }

--- a/scss/components/_components.code.scss
+++ b/scss/components/_components.code.scss
@@ -4,6 +4,6 @@
 
 
 .dcf-pre {
-  background-color: var(--bg-pre);
+  background-color: $bg-color-pre;
   padding: $padding-pre;
 }

--- a/scss/components/_components.datepickers.scss
+++ b/scss/components/_components.datepickers.scss
@@ -9,7 +9,7 @@
 
 
 .dcf-datepicker-dialog {
-  background-color: var(--bg-dialog);
+  background-color: $bg-color-datepicker-dialog;
   @if ($border-radius-datepicker-dialog-roundrect) {
     border-radius: $roundrect;
   }
@@ -44,7 +44,7 @@
   @if ($border-radius-datepicker-date-roundrect) {
     border-radius: $roundrect;
   }
-  color: var(--btn-tertiary);
+  color: $color-datepicker-dialog-calendar-td;
 }
 
 
@@ -54,8 +54,8 @@
 
 
 .dcf-datepicker-dialog-calendar td:not(.disabled):not([tabindex="0"]):not([aria-selected]):hover {
-  background-color: var(--bg-btn-secondary-tertiary-hover);
-  color: var(--btn-secondary-tertiary-hover);
+  background-color: $bg-color-datepicker-dialog-calendar-td-hover;
+  color: $color-datepicker-dialog-calendar-td-hover;
 }
 
 

--- a/scss/components/_components.forms-checkboxes-radios.scss
+++ b/scss/components/_components.forms-checkboxes-radios.scss
@@ -57,8 +57,8 @@
 // Style checkbox and radio input
 .dcf-input-checkbox label::before,
 .dcf-input-radio label::before {
-  background-color: var(--bg-input);
-  border: $border-width-input solid var(--b-input);
+  background-color: $bg-color-input;
+  border: $border-width-input solid $border-color-input;
   height: $height-width-checkbox-radio;
   width: $height-width-checkbox-radio;
 }
@@ -74,7 +74,7 @@
 // Style checkmark
 .dcf-input-checkbox label::after {
   background-color: transparent;
-  border-color: transparent var(--b-checkmark) var(--b-checkmark);
+  border-color: transparent $border-color-checkmark $border-color-checkmark;
   border-style: solid;
   border-width: 0 0 $border-width-checkmark $border-width-checkmark;
   height: to-number($height-width-checkbox-radio) * to-number(#{ms(-8)});
@@ -95,7 +95,7 @@
 
 // Style radio selection
 .dcf-input-radio label::after {
-  background-color: var(--bg-radio);
+  background-color: $bg-color-radio-dot;
   height: $height-width-checkbox-radio;
   opacity: 0;
   top: 0;
@@ -108,14 +108,14 @@
 // Checkbox and radio focus state
 .dcf-input-checkbox input[type="checkbox"]:focus + label::before,
 .dcf-input-radio input[type="radio"]:focus + label::before {
-  border-color: var(--b-input-focus);
+  border-color: $border-color-input-focus;
 }
 
 
 // Checkbox and radio checked state
 .dcf-input-checkbox input[type="checkbox"]:checked + label::before,
 .dcf-input-radio input[type="radio"]:checked + label::before {
-  border-color: var(--b-input-checked);
+  border-color: $border-color-input-checked;
 }
 
 
@@ -139,5 +139,5 @@
 .dcf-input-radio input[type="radio"]:enabled + label:hover::before,
 .dcf-input-checkbox input[type="checkbox"]:enabled:hover + label::before,
 .dcf-input-radio input[type="radio"]:enabled:hover + label::before {
-  border-color: var(--b-input-hover);
+  border-color: $border-color-input-hover;
 }

--- a/scss/components/_components.forms-selects.scss
+++ b/scss/components/_components.forms-selects.scss
@@ -56,6 +56,6 @@
 
 .dcf-input-select:focus, // TODO: deprecate .dcf-input-select?
 .dcf-form select:focus {
-  border-color: $border-color-input-focus);
+  border-color: $border-color-input-focus;
   outline: none;
 }

--- a/scss/components/_components.forms-selects.scss
+++ b/scss/components/_components.forms-selects.scss
@@ -10,19 +10,19 @@
   @include lh-4;
   @include txt-base; // Font size must be ≥16px to prevent iOS page zoom on focus
   appearance: none;
-  background-color: var(--bg-select-2); // This is necessary for select options dropdown/popover in dark mode
-  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='#{encodecolor($color-select-arrow-light-mode)}' d='M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z'/%3E%3C/svg%3E"), linear-gradient(var(--bg-select-1), var(--bg-select-2));
+  background-color: $bg-color-select-2; // This is necessary for select options dropdown/popover in dark mode
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='#{encodecolor($color-select-arrow-light-mode)}' d='M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z'/%3E%3C/svg%3E"), linear-gradient($bg-color-select-1, $bg-color-select-2);
   background-position: right $bg-position-arrow top 50%, 0 0;
   background-repeat: no-repeat, repeat;
   background-size: $bg-size-arrow-select $bg-size-arrow-select, 100%;
-  border: $border-width-input solid var(--b-input);
+  border: $border-width-input solid $bg-color-input;
   @if ($border-radius-input-roundrect) {
     border-radius: $roundrect;
   } @else {
     border-radius: 0;
   }
   box-sizing: border-box;
-  color: var(--select);
+  color: $color-select;
   cursor: pointer;
   display: block;
   font-family: inherit;
@@ -37,7 +37,7 @@
   .dcf-input-select, // TODO: deprecate .dcf-input-select?
   .dcf-form select {
     // Change select arrow color for dark mode
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='#{encodecolor($color-select-arrow-dark-mode)}' d='M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z'/%3E%3C/svg%3E"), linear-gradient(var(--bg-select-1), var(--bg-select-2));
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='#{encodecolor($color-select-arrow-dark-mode)}' d='M23.9 2.3c-.1-.2-.2-.3-.4-.3H.5c-.2 0-.3.1-.4.3-.1.1-.1.3 0 .5l11.5 19c.1.1.3.2.4.2s.3-.1.4-.2l11.5-19c.1-.2.1-.4 0-.5z'/%3E%3C/svg%3E"), linear-gradient($bg-color-select-1, $bg-color-select-2);
   }
 }
 
@@ -50,12 +50,12 @@
 
 .dcf-input-select:hover, // TODO: deprecate .dcf-input-select?
 .dcf-form select:hover {
-  border-color: var(--b-input-hover);
+  border-color: $border-color-input-hover;
 }
 
 
 .dcf-input-select:focus, // TODO: deprecate .dcf-input-select?
 .dcf-form select:focus {
-  border-color: var(--b-input-focus);
+  border-color: $border-color-input-focus);
   outline: none;
 }

--- a/scss/components/_components.forms.scss
+++ b/scss/components/_components.forms.scss
@@ -5,7 +5,7 @@
 
 // Fieldset
 .dcf-form fieldset {
-  border: $border-width-input $border-style-input var(--b-fieldset);
+  border: $border-width-input $border-style-input $border-color-fieldset;
   @if ($border-radius-fieldset-roundrect) {
     border-radius: $roundrect;
   }
@@ -56,7 +56,7 @@
 
 // Required
 .dcf-required {
-  color: var(--required);
+  color: $color-required-label;
   font-size: $font-size-required;
   @if ($font-style-required-italic) {
     font-style: italic;
@@ -68,7 +68,7 @@
 
 // Form help
 .dcf-form-help {
-  color: var(--form-help);
+  color: $color-form-help;
   display: inline-block;
   font-size: $font-size-form-help;
   line-height: $line-height-form-help;
@@ -80,8 +80,8 @@
 .dcf-input-text, // TODO: deprecate .dcf-input-text?
 .dcf-form input:not([type="file"]):not([type="submit"]),
 .dcf-form textarea {
-  background-color: var(--bg-input, $default-bg-input);
-  border: $border-width-input $border-style-input var(--b-input, $default-b-input);
+  background-color: $bg-color-input;
+  border: $border-width-input $border-style-input $border-color-input;
   @if ($border-radius-input-roundrect) {
     border-radius: $roundrect;
   } @else {
@@ -100,7 +100,7 @@
 .dcf-input-text:focus, // TODO: deprecate .dcf-input-text?
 .dcf-form input:not([type="submit"]):focus,
 .dcf-form textarea:focus {
-  border-color: var(--b-input-focus);
+  border-color: $border-color-input-focus;
   outline: none;
 }
 
@@ -108,7 +108,7 @@
 .dcf-input-text:enabled:hover, // TODO: deprecate .dcf-input-text?
 .dcf-form input:not([type="submit"]):enabled:hover,
 .dcf-form textarea:enabled:hover {
-  border-color: var(--b-input-hover);
+  border-color: $border-color-input-hover;
 }
 
 

--- a/scss/components/_components.input-groups.scss
+++ b/scss/components/_components.input-groups.scss
@@ -37,9 +37,9 @@
 // Input group add-on
 .dcf-input-group-addon {
   align-items: center;
-  background-color: var(--bg-input-group-addon);
-  border: $border-width-input-group-addon $border-style-input-group-addon var(--b-input-group-addon);
-  color: var(--input-group-addon);
+  background-color: $bg-color-input-group-addon;
+  border: $border-width-input-group-addon $border-style-input-group-addon $border-color-input-group-addon;
+  color: $color-input-group-addon;
   display: flex;
   @if (to-number($font-size-input-group-addon) != to-number(#{ms(0)}em)) {
     font-size: $font-size-input-group-addon;

--- a/scss/components/_components.modals.scss
+++ b/scss/components/_components.modals.scss
@@ -11,7 +11,7 @@
 
 // Modal wrapper
 .dcf-modal-wrapper {
-  background-color: var(--bg-modal-wrapper);
+  background-color: $bg-color-modal-wrapper;
   max-height: $height-max-modal-wrapper;
   width: $width-modal-wrapper;
 }
@@ -19,7 +19,7 @@
 
 // Modal header
 .dcf-modal-header {
-  background-color: var(--bg-modal-header);
+  background-color: $bg-color-modal-header;
 }
 
 

--- a/scss/components/_components.nav-menu.scss
+++ b/scss/components/_components.nav-menu.scss
@@ -10,9 +10,11 @@
   padding-left: 0;
 }
 
+
 .dcf-nav-menu li {
   margin-bottom: 0;
 }
+
 
 .dcf-nav-menu-child a,
 .dcf-nav-menu-child button {
@@ -21,10 +23,11 @@
   padding: #{ms(0)}em #{ms(0)}rem;
 }
 
+
 @include mq(md, max, width) {
 
   .dcf-nav-menu {
-    background-color: var(--nav-menu-bg-color, $default-nav-menu-bg-color);
+    background-color: $bg-color-nav-menu;
     bottom: #{ms(10)}em;
     height: 100vh;
     opacity: 0;
@@ -35,6 +38,7 @@
     width: 100%;
     z-index: 998; // Ensure that the z-index is below the modal and nav-toggle-group z-indices
   }
+
 
   // Open when parent model is open
   .dcf-nav-menu.dcf-modal-open {
@@ -55,13 +59,16 @@
     position: fixed;
   }
 
+
   .dcf-nav-menu-child > *:first-child {
     @include mt-6;
   }
 
+
   .dcf-nav-menu-child > *:last-child {
     @include mb-7;
   }
+
 
   .dcf-nav-menu-child::before,
   .dcf-nav-menu-child::after {
@@ -72,6 +79,7 @@
     width: 100%;
     z-index: 999;
   }
+
 
   .dcf-nav-menu a,
   .dcf-nav-menu button {
@@ -84,6 +92,7 @@
   }
 
 }
+
 
 @include mq(md, min, width) {
 

--- a/scss/components/_components.nav-toggle.scss
+++ b/scss/components/_components.nav-toggle.scss
@@ -1,16 +1,17 @@
-///////////////////////////////////
+//////////////////////////////////
 // CORE / COMPONENTS / NAV: TOGGLE
-///////////////////////////////////
+//////////////////////////////////
 
 
 .dcf-nav-toggle-btn {
   appearance: none;
 }
 
+
 @include mq(md, max, width) {
 
   .dcf-nav-toggle-group {
-    background-color: var(--bg-nav-toggle-group, $default-bg-nav-toggle-group);
+    background-color: $bg-color-nav-toggle-group;
     display: flex;
     z-index: $z-nav-toggle-group;
 
@@ -36,6 +37,7 @@
   .dcf-nav-menu .dcf-nav-toggle-btn-menu {
     display: none;
   }
+
 
   .headroom {
     transition: transform 250ms ease-out !important;

--- a/scss/components/_components.notices.scss
+++ b/scss/components/_components.notices.scss
@@ -8,9 +8,11 @@
   @include mb-0;
 }
 
+
 .dcf-notice-icon {
   grid-area: 2 / 2 / 3 / 3;
 }
+
 
 .dcf-notice-close {
   padding-right: #{ms(-10)}em;
@@ -24,9 +26,11 @@
     grid-template-rows: $length-em-5 $length-em-6 $length-em-3 auto $length-em-2 $length-em-5;
   }
 
+
   .dcf-notice-body {
     grid-area: 4 / 2 / 5 / 5;
   }
+
 
   .dcf-notice-close {
     @include pt-3;
@@ -43,9 +47,11 @@
     grid-template-rows: $length-em-5 auto $length-em-5;
   }
 
+
   .dcf-notice-body {
     grid-area: 2 / 4 / 3 / 5;
   }
+
 
   .dcf-notice-close {
     grid-area: 1 / -2 / 3 / -1;
@@ -60,6 +66,7 @@
   background-color: $bg-color-notice-info;
 }
 
+
 .dcf-notice-info .dcf-notice-message {
   color: $color-notice-info;
 }
@@ -69,6 +76,7 @@
 .dcf-notice-success {
   background-color: $bg-color-notice-success;
 }
+
 
 .dcf-notice-success .dcf-notice-message {
   color: $bg-color-notice-success;
@@ -80,6 +88,7 @@
   background-color: $bg-color-notice-warning;
 }
 
+
 .dcf-notice-warning .dcf-notice-message {
   color: $bg-color-notice-warning;
 }
@@ -89,6 +98,7 @@
 .dcf-notice-danger {
   background-color: $bg-color-notice-danger;
 }
+
 
 .dcf-notice-danger .dcf-notice-message {
   color: $bg-color-notice-danger;

--- a/scss/components/_components.notices.scss
+++ b/scss/components/_components.notices.scss
@@ -79,7 +79,7 @@
 
 
 .dcf-notice-success .dcf-notice-message {
-  color: $bg-color-notice-success;
+  color: $color-notice-success;
 }
 
 
@@ -90,7 +90,7 @@
 
 
 .dcf-notice-warning .dcf-notice-message {
-  color: $bg-color-notice-warning;
+  color: $color-notice-warning;
 }
 
 
@@ -101,7 +101,7 @@
 
 
 .dcf-notice-danger .dcf-notice-message {
-  color: $bg-color-notice-danger;
+  color: $color-notice-danger;
 }
 
 

--- a/scss/components/_components.notices.scss
+++ b/scss/components/_components.notices.scss
@@ -57,41 +57,41 @@
 
 // Info
 .dcf-notice-info {
-  background-color: var(--bg-notice-info);
+  background-color: $bg-color-notice-info;
 }
 
 .dcf-notice-info .dcf-notice-message {
-  color: var(--notice-info);
+  color: $color-notice-info;
 }
 
 
 // Success
 .dcf-notice-success {
-  background-color: var(--bg-notice-success);
+  background-color: $bg-color-notice-success;
 }
 
 .dcf-notice-success .dcf-notice-message {
-  color: var(--notice-success);
+  color: $bg-color-notice-success;
 }
 
 
 // Warning
 .dcf-notice-warning {
-  background-color: var(--bg-notice-warning);
+  background-color: $bg-color-notice-warning;
 }
 
 .dcf-notice-warning .dcf-notice-message {
-  color: var(--notice-warning);
+  color: $bg-color-notice-warning;
 }
 
 
 // Danger
 .dcf-notice-danger {
-  background-color: var(--bg-notice-danger);
+  background-color: $bg-color-notice-danger;
 }
 
 .dcf-notice-danger .dcf-notice-message {
-  color: var(--notice-danger);
+  color: $bg-color-notice-danger;
 }
 
 

--- a/scss/components/_components.pagination.scss
+++ b/scss/components/_components.pagination.scss
@@ -2,39 +2,48 @@
 // CORE / COMPONENTS / PAGINATION
 /////////////////////////////////
 
+
 .dcf-pagination-selected .dcf-btn {
   cursor: not-allowed !important;
 }
+
 
 .dcf-pagination span {
   padding: $length-em-3 $length-em-1;
 }
 
+
 .dcf-pagination li {
   margin: 0;
 }
+
 
 .dcf-pagination-first::before,
 .dcf-pagination-prev::before {
   margin-right: #{ms(-12)}em;
 }
 
+
 .dcf-pagination-first::before {
   content: '\21E4';
 }
 
+
 .dcf-pagination-prev::before {
   content: '\2190';
 }
+
 
 .dcf-pagination-next::after,
 .dcf-pagination-last::after {
   margin-left: #{ms(-12)}em;
 }
 
+
 .dcf-pagination-next::after {
   content: '\2192';
 }
+
 
 .dcf-pagination-last::after {
   content: '\21E5';

--- a/scss/components/_components.tables.scss
+++ b/scss/components/_components.tables.scss
@@ -4,7 +4,7 @@
 
 
 .dcf-table caption {
-  color: var(--caption);
+  color: $color-caption;
   // If the caption font-size is not 1em, then change the font-size
   @if (to-number($font-size-caption) != to-number(#{ms(0)}em)) {
     font-size: $font-size-caption;
@@ -23,8 +23,8 @@
 
 
 .dcf-table tbody {
-  border-bottom: $border-width-table $border-style-table var(--b-table);
-  border-top: $border-width-table $border-style-table var(--b-table);
+  border-bottom: $border-width-table $border-style-table $border-color-table;
+  border-top: $border-width-table $border-style-table $border-color-table;
   font-size: $font-size-tbody;
 }
 
@@ -43,7 +43,7 @@
 .dcf-table-bordered,
 .dcf-table-bordered td,
 .dcf-table-bordered th {
-  border: $border-width-table $border-style-table var(--b-table);
+  border: $border-width-table $border-style-table $border-color-table;
 }
 
 
@@ -58,12 +58,12 @@
 
 .dcf-table-bordered tr:not(:last-child),
 .dcf-table-striped tr:not(:last-child) {
-  border-bottom: $border-width-table $border-style-table var(--b-table);
+  border-bottom: $border-width-table $border-style-table $border-color-table;
 }
 
 
 .dcf-table-striped tbody tr:nth-of-type(even) {
-  background-color: var(--bg-table-stripe);
+  background-color: $bg-color-table-stripe;
 }
 
 

--- a/scss/components/_components.tabs.scss
+++ b/scss/components/_components.tabs.scss
@@ -22,17 +22,17 @@
 
 
 .dcf-tab[aria-selected] {
-  background-color: var(--bg-tab-selected);
-  color: var(--tab-selected);
+  background-color: $bg-color-tab-selected;
+  color: $color-tab-selected;
   text-decoration: none;
 }
 
 
 .dcf-tabs-panel {
-  background-color: var(--bg-tabs-panel);
+  background-color: $bg-color-tabs-panel;
   // If tab panel border-width is greater than zero, then add border styles
   @if (to-number($border-width-tabs-panel) > 0) {
-    border: $border-width-tabs-panel $border-style-tabs-panel var(--b-tabs-panel);
+    border: $border-width-tabs-panel $border-style-tabs-panel $border-color-tabs-panel;
   }
   padding: $padding-top-tabs-panel $padding-right-tabs-panel $padding-bottom-tabs-panel $padding-left-tabs-panel;
 }

--- a/scss/elements/_elements.anchors.scss
+++ b/scss/elements/_elements.anchors.scss
@@ -5,23 +5,23 @@
 
 // Link
 a:link {
-  color: var(--link);
+  color: $color-link;
 }
 
 
 // Visited
 a:visited {
-  color: var(--visited);
+  color: $color-visited;
 }
 
 
 // Hover
 a:hover {
-  color: var(--hover);
+  color: $color-hover;
 }
 
 
 // Active
 a:active {
-  color: var(--active);
+  color: $color-active;
 }

--- a/scss/elements/_elements.body.scss
+++ b/scss/elements/_elements.body.scss
@@ -4,8 +4,8 @@
 
 
 body {
-  background-color: var(--bg-body);
-  color: var(--body);
+  background-color: $bg-color-body;
+  color: $color-body;
   margin: 0;
   overflow-x: hidden;
 }

--- a/scss/elements/_elements.code.scss
+++ b/scss/elements/_elements.code.scss
@@ -22,8 +22,8 @@ pre {
 
 
 code {
-  background-color: var(--bg-code);
-  color: var(--code);
+  background-color: $bg-color-code;
+  color: $color-code;
   font-size: $font-size-code;
   padding: $padding-code;
 }
@@ -44,8 +44,8 @@ pre code {
 
 
 kbd {
-  background-color: var(--bg-kbd);
-  color: var(--kbd);
+  background-color: $bg-color-kbd;
+  color: $color-kbd;
   font-size: $font-size-kbd;
   padding: $padding-kbd;
 }

--- a/scss/elements/_elements.figures.scss
+++ b/scss/elements/_elements.figures.scss
@@ -11,6 +11,6 @@ figure {
 
 // Figure caption
 figcaption {
-  color: var(--figcaption);
+  color: $color-figcaption;
   font-size: $font-size-figcaption;
 }

--- a/scss/elements/_elements.headings.scss
+++ b/scss/elements/_elements.headings.scss
@@ -17,7 +17,7 @@ h3,
 h4,
 h5,
 h6 {
-  color: var(--heading);
+  color: $color-heading;
   line-height: $line-height-heading;
   margin-bottom: $margin-bottom-heading;
   margin-top: $margin-top-heading;

--- a/scss/elements/_elements.marks.scss
+++ b/scss/elements/_elements.marks.scss
@@ -5,6 +5,6 @@
 
 // Marked (highlighted) text
 mark {
-  background-color: var(--bg-mark);
+  background-color: $bg-color-mark;
   padding: $padding-top-mark $padding-right-mark $padding-bottom-mark $padding-left-mark;
 }

--- a/scss/elements/_elements.sub-sup.scss
+++ b/scss/elements/_elements.sub-sup.scss
@@ -14,11 +14,11 @@ sup {
 
 // Subscript
 sub {
-  bottom: $position-sub;
+  bottom: $bottom-sub;
 }
 
 
 // Superscript
 sup {
-  bottom: $position-sup;
+  bottom: $bottom-sup;
 }

--- a/scss/mixins/_mixins.backgrounds.scss
+++ b/scss/mixins/_mixins.backgrounds.scss
@@ -5,9 +5,9 @@
 
 // Color
 @mixin bg-transparent($imp:null) { background-color: transparent $imp; }
-@mixin bg-white($imp:null) { background-color: var(--bg-white, $default-bg-white) $imp; }
-@mixin bg-overlay-dark($imp:null) { background-color: var(--bg-overlay-dark, $default-bg-overlay-dark) $imp; }
-@mixin bg-overlay-light($imp:null) { background-color: var(--bg-overlay-light, $default-bg-overlay-light) $imp; }
+@mixin bg-white($imp:null) { background-color: $bg-color-white $imp; }
+@mixin bg-overlay-dark($imp:null) { background-color: $bg-color-overlay-dark $imp; }
+@mixin bg-overlay-light($imp:null) { background-color: $bg-color-overlay-light $imp; }
 
 
 // Position

--- a/scss/mixins/_mixins.colors.scss
+++ b/scss/mixins/_mixins.colors.scss
@@ -4,8 +4,8 @@
 
 
 // Inverse (light text for dark backgrounds)
-@mixin inverse($imp:null) { color: var(--inverse) $imp; }
-@mixin inverse-link($imp:null) { color: var(--inverse-link) $imp; }         // Link
-@mixin inverse-visited($imp:null) { color: var(--inverse-visited) $imp; }   // Visited
-@mixin inverse-hover($imp:null) { color: var(--inverse-hover) $imp; }       // Hover
-@mixin inverse-active($imp:null) { color: var(--inverse-active) $imp; }     // Active
+@mixin inverse($imp:null) { color: $color-inverse $imp; }
+@mixin inverse-link($imp:null) { color: $color-inverse-link $imp; }         // Link
+@mixin inverse-visited($imp:null) { color: $color-inverse-visited $imp; }   // Visited
+@mixin inverse-hover($imp:null) { color: $color-inverse-hover $imp; }       // Hover
+@mixin inverse-active($imp:null) { color: $color-inverse-active $imp; }     // Active

--- a/scss/variables/_variables.tmp-defaults.scss
+++ b/scss/variables/_variables.tmp-defaults.scss
@@ -3,15 +3,19 @@
 ///////////////////////////////
 
 
+$black: #000;
+$white: #fff;
+
+
 // Background color
-$default-bg-white: #fff;
-$default-bg-overlay-dark: fade-out(#000, .06);
-$default-bg-overlay-light: fade-out(#fff, .06);
-$default-bg-input: #fff;
-$default-bg-nav-menu: #fff;
-$default-bg-nav-toggle-group: #fff;
+$default-bg-white: $white;
+$default-bg-overlay-dark: fade-out($black, .06);
+$default-bg-overlay-light: fade-out($white, .06);
+$default-bg-input: $white;
+$default-bg-nav-menu: $white;
+$default-bg-nav-toggle-group: $white;
 
 
 // Border color
 $default-b-input: #ccc;
-$default-b-app-control: #000;
+$default-b-app-control: $black;

--- a/scss/variables/_variables.tmp-defaults.scss
+++ b/scss/variables/_variables.tmp-defaults.scss
@@ -1,13 +1,17 @@
-////////////////////////////////////
+///////////////////////////////
 // THEME / VARIABLES / DEFAULTS
-////////////////////////////////////
+///////////////////////////////
 
+
+// Background color
 $default-bg-white: #fff;
-$default-bg-overlay-dark: fade-out(#000, .06); ;
-$default-bg-overlay-light: fade-out(#fefdfa, .06);
-$default-app-control-border-color: #000;
-$default-nav-menu-bg-color: #fefdfa;
+$default-bg-overlay-dark: fade-out(#000, .06);
+$default-bg-overlay-light: fade-out(#fff, .06);
+$default-bg-input: #fff;
+$default-bg-nav-menu: #fff;
 $default-bg-nav-toggle-group: #fff;
 
-$default-bg-input: #fff;
-$default-b-input: #c7c8ca;
+
+// Border color
+$default-b-input: #ccc;
+$default-b-app-control: #000;


### PR DESCRIPTION
- Update default color variables
- Replace CSS variables with Sass variables for greater flexibility. (CSS variables can still be set at the theme level, but sites can also use static values [e.g., hex, RGB, or HSL colors] if desired for some or all values.)