### PR TITLE
Remove iOS-specific modal JS

### DIFF
--- a/js/dcf-modal.js
+++ b/js/dcf-modal.js
@@ -159,11 +159,6 @@ export class DCFModal {
           let currentEl = el;
           while (currentEl && currentEl !== document.body) {
             if (currentEl.classList.contains('dcf-modal-content')) {
-              const iOSBodyStyle = {
-                WebkitOverflowScrolling: 'none',
-                overflow: 'hidden',
-              };
-              Object.assign(document.body.style, iOSBodyStyle);
               return true;
             }
             if (currentEl.parentElement) {


### PR DESCRIPTION
JS would allow modal content to scroll, but once the modal was closed scrolling was inconsistent.