### PR TITLE
Update position classes

### DIFF
--- a/js/dcf-autoplayVideoToggle.js
+++ b/js/dcf-autoplayVideoToggle.js
@@ -2,7 +2,7 @@ export class DCFAutoplayVideoToggleTheme {
   constructor() {
     // Defaults
     /* eslint-disable */
-    this.toggleBtnClassList = [ 'dcf-btn-autoplay-video-toggle', 'dcf-btn', 'dcf-btn-primary', 'dcf-z-1', 'dcf-absolute', 'dcf-pin-bottom', 'dcf-pin-right', 'dcf-d-flex', 'dcf-ai-center', 'dcf-jc-center', 'dcf-mb-3', 'dcf-mr-3', 'dcf-h-7', 'dcf-w-7', 'dcf-p-0', 'dcf-circle' ];
+    this.toggleBtnClassList = [ 'dcf-btn-autoplay-video-toggle', 'dcf-btn', 'dcf-btn-primary', 'dcf-z-1', 'dcf-absolute', 'dcf-bottom-0', 'dcf-right-0', 'dcf-d-flex', 'dcf-ai-center', 'dcf-jc-center', 'dcf-mb-3', 'dcf-mr-3', 'dcf-h-7', 'dcf-w-7', 'dcf-p-0', 'dcf-circle' ];
     this.togglePlayBtnInnerHTML = '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" focusable="false" aria-hidden="true"><path d="M21.759 11.577L2.786.077a.499.499 0 0 0-.759.428v23a.498.498 0 0 0 .5.5c.09 0 .18-.024.259-.072l18.973-11.5a.5.5 0 0 0 0-.856z"></path></svg>';
     this.togglePauseBtnInnerHTML = '<svg class="dcf-h-4 dcf-w-4 dcf-fill-current" width="24" height="24" viewBox="0 0 24 24" focusable="false" aria-hidden="true"><path d="M10.5 0h-5C5.224 0 5 .224 5 .5v23C5 23.776 5.224 24 5.5 24h5c.276 0 .5-.224.5-.5v-23C11 .224 10.776 0 10.5 0zM18.5 0h-5C13.224 0 13 .224 13 .5v23c0 .276.224.5.5.5h5c.276 0 .5-.224.5-.5v-23C19 .224 18.776 0 18.5 0z"></path></svg>';
     /* eslint-enable */

--- a/js/dcf-datepicker.js
+++ b/js/dcf-datepicker.js
@@ -83,7 +83,7 @@ export class DCFDatepicker {
     this.dialogNode.setAttribute('role', 'dialog');
     this.dialogNode.setAttribute('aria-modal', 'true');
     this.dialogNode.setAttribute('aria-labelledby', dialogLabelID);
-    this.dialogNode.classList.add('dcf-datepicker-dialog', 'dcf-absolute', 'dcf-pin-right', 'dcf-invisible', 'dcf-d-none');
+    this.dialogNode.classList.add('dcf-datepicker-dialog', 'dcf-absolute', 'dcf-right-0', 'dcf-invisible', 'dcf-d-none');
 
     let dialogHeader = document.createElement('div');
     dialogHeader.classList.add('dcf-datepicker-dialog-header', 'dcf-d-flex', 'dcf-ai-center', 'dcf-jc-around');

--- a/js/dcf-modal.js
+++ b/js/dcf-modal.js
@@ -425,7 +425,7 @@ export class DCFModal {
       }
 
       // Add default utility classes to each modal
-      modal.classList.add('dcf-fixed', 'dcf-pin-top', 'dcf-pin-left', 'dcf-h-100%', 'dcf-w-100%', 'dcf-d-flex', 'dcf-ai-center',
+      modal.classList.add('dcf-fixed', 'dcf-top-0', 'dcf-left-0', 'dcf-h-100%', 'dcf-w-100%', 'dcf-d-flex', 'dcf-ai-center',
         'dcf-jc-center', 'dcf-opacity-0', 'dcf-pointer-events-none', 'dcf-invisible');
 
       // Set attribute for modal wrapper
@@ -442,14 +442,14 @@ export class DCFModal {
       if (modalHeader.classList.length === DCFUtility.magicNumbers('int1') &&
         modalHeader.classList.contains('dcf-modal-header')) {
         // If no custom classes are present, add default utility classes to modal header
-        modalHeader.classList.add('dcf-wrapper', 'dcf-pt-8', 'dcf-sticky', 'dcf-pin-top');
+        modalHeader.classList.add('dcf-wrapper', 'dcf-pt-8', 'dcf-sticky', 'dcf-top-0');
       }
 
       // Check each 'close' button for any additional classes
       if (btnCloseModal.classList.length === DCFUtility.magicNumbers('int1') &&
         btnCloseModal.classList.contains('dcf-btn-close-modal')) {
         // If no custom classes are present, add default utility classes to 'close' button
-        btnCloseModal.classList.add('dcf-btn', 'dcf-btn-tertiary', 'dcf-absolute', 'dcf-pin-top', 'dcf-pin-right', 'dcf-z-1');
+        btnCloseModal.classList.add('dcf-btn', 'dcf-btn-tertiary', 'dcf-absolute', 'dcf-top-0', 'dcf-right-0', 'dcf-z-1');
       }
 
       // Check modal content for any additional classes

--- a/js/dcf-slideshow.js
+++ b/js/dcf-slideshow.js
@@ -188,14 +188,14 @@ class SlideshowObj {
     ctrls.classList.add('dcf-slideshow-controls',
       'dcf-btn-group',
       'dcf-absolute',
-      'dcf-pin-right',
+      'dcf-right-0',
       'dcf-z-1');
 
     // If data-toggle-caption is false then move it to the top
     if (this.slideshow.getAttribute('data-toggle-caption') === 'false') {
-      ctrls.classList.add('dcf-pin-top');
+      ctrls.classList.add('dcf-top-0');
     } else {
-      ctrls.classList.add('dcf-pin-bottom');
+      ctrls.classList.add('dcf-bottom-0');
     }
 
     // Add role and aria-label to controls group

--- a/scss/mixins/_mixins.position.scss
+++ b/scss/mixins/_mixins.position.scss
@@ -8,13 +8,7 @@
 @mixin relative($imp:null) { position: relative $imp; } // Relative
 @mixin absolute($imp:null) { position: absolute $imp; } // Absolute
 @mixin fixed($imp:null) { position: fixed $imp; }       // Fixed
-@mixin sticky($imp:null) {                              // Sticky
-
-  @supports (position: sticky) {
-    position: sticky $imp;
-  }
-
-}
+@mixin sticky($imp:null) { position: sticky $imp; }     // Sticky
 
 
 // Coordinates

--- a/scss/mixins/_mixins.position.scss
+++ b/scss/mixins/_mixins.position.scss
@@ -18,7 +18,14 @@
 
 
 // Coordinates
-@mixin pin-top($imp:null) { top: 0 $imp; }        // Pin To Top
-@mixin pin-right($imp:null) { right: 0 $imp; }    // Pin To Right
-@mixin pin-bottom($imp:null) { bottom: 0 $imp; }  // Pin To Bottom
-@mixin pin-left($imp:null) { left: 0 $imp; }      // Pin To Left
+@mixin top-0($imp:null) { top: 0 $imp; }
+@mixin top-100pc($imp:null) { top: 100% $imp; }
+
+@mixin right-0($imp:null) { right: 0 $imp; }
+@mixin right-100pc($imp:null) { right: 100% $imp; }
+
+@mixin bottom-0($imp:null) { bottom: 0 $imp; }
+@mixin bottom-100pc($imp:null) { bottom: 100% $imp; }
+
+@mixin left-0($imp:null) { left: 0 $imp; }
+@mixin left-100pc($imp:null) { left: 100% $imp; }

--- a/scss/utilities/_utilities.position.scss
+++ b/scss/utilities/_utilities.position.scss
@@ -12,7 +12,41 @@
 
 
 // Coordinates
-.dcf-pin-top { @include pin-top(!important); }        // Pin To Top
-.dcf-pin-right { @include pin-right(!important); }    // Pin To Right
-.dcf-pin-bottom { @include pin-bottom(!important); }  // Pin To Bottom
-.dcf-pin-left { @include pin-left(!important); }      // Pin To Left
+.dcf-pin-top, // Deprecate .dcf-pin-top
+.dcf-top-0 {
+  @include top-0(!important);
+}
+
+.dcf-top-100% {
+  @include top-100pc(!important);
+}
+
+
+.dcf-pin-right, // Deprecate .dcf-pin-right
+.dcf-right-0 {
+  @include right-0(!important);
+}
+
+.dcf-right-100% {
+  @include right-100pc(!important);
+}
+
+
+.dcf-pin-bottom, // Deprecate .dcf-pin-bottom
+.dcf-bottom-0 {
+  @include bottom-0(!important);
+}
+
+.dcf-bottom-100% {
+  @include bottom-100pc(!important);
+}
+
+
+.dcf-pin-left, // Deprecate .dcf-pin-left
+.dcf-left-0 {
+  @include left-0(!important);
+}
+
+.dcf-left-100% {
+  @include left-100pc(!important);
+}


### PR DESCRIPTION
- Add `0` and `100%` values for location (`top`, `right`, `bottom`, `left`) mixins/utilities with note to eventually deprecate `dcf-pin-*` classes.
- Remove `@supports` feature query from `position: sticky`