### PR TITLE
Ready Event For Collapsible Fieldset 

### DIFF
--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -53,6 +53,8 @@ export class DCFFieldsetCollapsible {
       this.theme = new DCFFieldsetCollapsibleTheme();
     }
 
+    this.fieldsetReadyEvent = new Event(DCFFieldsetCollapsible.events('fieldsetReady'));
+
     // Copy the Keys without copying the references
     // Objects plus their properties and arrays are pass by reference
     this.toggleKeys = [];
@@ -90,6 +92,7 @@ export class DCFFieldsetCollapsible {
   static events(name) {
     // Define any new events
     const events = {
+      fieldsetReady: 'ready',
     };
     Object.freeze(events);
 
@@ -180,6 +183,8 @@ export class DCFFieldsetCollapsible {
         offKeys:    this.offKeys,
       });
       toggleButtonObj.initialize();
+
+      fieldset.dispatchEvent(this.fieldsetReadyEvent);
     });
   }
 


### PR DESCRIPTION
Due to the way collapsible fieldsets have to copy the contents to a new div any references to elements inside the fieldset will be invalid. This leads to trouble when creating code to interact with those elements