### PR TITLE
Update default variables for popups

### DIFF
--- a/scss/variables/_variables.tmp-defaults.scss
+++ b/scss/variables/_variables.tmp-defaults.scss
@@ -22,9 +22,9 @@ $default-b-app-control: $black;
 
 
 // Margin
-$margin-popup-point: $length-em-4;
+$margin-popup-point: 1em;
 
 
 // Size of popup arrow/point
-$size-block-popup-point: $length-em-3;
-$size-inline-popup-point: $length-em-4;
+$size-block-popup-point: .75em;
+$size-inline-popup-point: 1em;


### PR DESCRIPTION
Length variables exist at the theme level and aren’t present in DCF core. Default values are now provided here instead.