### PR TITLE
Animation block

### DIFF
--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -34,6 +34,9 @@ export class DCFFieldsetCollapsibleTheme {
     this.fieldsetClassListOn = [];
 
     this.fieldsetClassListOff = [];
+
+    this.animationBlockWaitTime = 250;
+    this.animationBlockClassList = [ 'dcf-block-transition', 'dcf-block-animation' ];
   }
 
   // Allows us to set the theme variables if they are defined and we match the types
@@ -137,21 +140,40 @@ export class DCFFieldsetCollapsible {
       this.theme.fieldsetContentsClassList.forEach((divClass) => {
         newGuts.classList.add(divClass);
       });
-      this.theme.fieldsetContentsClassListOn.forEach((divClass) => {
-        newGuts.classList.add(divClass);
-      });
+      if (fieldsetStartExpanded === 'true') {
+        this.theme.fieldsetContentsClassListOn.forEach((divClass) => {
+          newGuts.classList.add(divClass);
+        });
+      } else {
+        this.theme.fieldsetContentsClassListOff.forEach((divClass) => {
+          newGuts.classList.add(divClass);
+        });
+      }
 
       // We can then add the new div and legend back into the fieldset
       fieldset.innerHTML = '';
       fieldset.append(legendCopy);
       fieldset.append(newGuts);
+
+      // Block any animations from running on load
+      // These get removed during first event listener
+      this.theme.animationBlockClassList.forEach((fieldsetClass) => {
+        fieldset.classList.add(fieldsetClass);
+      });
+
       // We can also add any styles
       this.theme.fieldsetClassList.forEach((fieldsetClass) => {
         fieldset.classList.add(fieldsetClass);
       });
-      this.theme.fieldsetClassListOn.forEach((fieldsetClass) => {
-        fieldset.classList.add(fieldsetClass);
-      });
+      if (fieldsetStartExpanded === 'true') {
+        this.theme.fieldsetClassListOn.forEach((fieldsetClass) => {
+          fieldset.classList.add(fieldsetClass);
+        });
+      } else {
+        this.theme.fieldsetClassListOff.forEach((fieldsetClass) => {
+          fieldset.classList.add(fieldsetClass);
+        });
+      }
 
       // We then make the button to be put into the legend
       const button = document.createElement('button');
@@ -185,6 +207,12 @@ export class DCFFieldsetCollapsible {
       toggleButtonObj.initialize();
 
       fieldset.dispatchEvent(this.fieldsetReadyEvent);
+
+      setTimeout(() => {
+        this.theme.animationBlockClassList.forEach((fieldsetClass) => {
+          fieldset.classList.remove(fieldsetClass);
+        });
+      }, this.theme.animationBlockWaitTime);
     });
   }
 
@@ -198,6 +226,7 @@ export class DCFFieldsetCollapsible {
   eventListeners(fieldset, toggleElement, button) {
     // We listen for when the toggle element is turned on
     toggleElement.addEventListener(DCFFieldsetCollapsible.events('toggleElementOn'), () => {
+      console.log(fieldset, 'on');
       // When it is we will remove the off styles and add the on styles
       this.theme.fieldsetContentsClassListOff.forEach((toggleElementClass) => {
         toggleElement.classList.remove(toggleElementClass);
@@ -217,6 +246,7 @@ export class DCFFieldsetCollapsible {
 
     // We listen for when the toggle element is turned off
     toggleElement.addEventListener(DCFFieldsetCollapsible.events('toggleElementOff'), () => {
+      console.log(fieldset, 'off');
       // When it is we will remove the on styles and add the off styles
       this.theme.fieldsetContentsClassListOn.forEach((toggleElementClass) => {
         toggleElement.classList.remove(toggleElementClass);

--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -35,7 +35,6 @@ export class DCFFieldsetCollapsibleTheme {
 
     this.fieldsetClassListOff = [];
 
-    this.animationBlockWaitTime = 250;
     this.animationBlockClassList = [ 'dcf-motion-none' ];
   }
 
@@ -208,11 +207,14 @@ export class DCFFieldsetCollapsible {
 
       fieldset.dispatchEvent(this.fieldsetReadyEvent);
 
-      setTimeout(() => {
+      let removeAnimationBlock = () => {
         this.theme.animationBlockClassList.forEach((fieldsetClass) => {
           fieldset.classList.remove(fieldsetClass);
         });
-      }, this.theme.animationBlockWaitTime);
+        fieldset.removeEventListener('transitionend', removeAnimationBlock);
+      };
+
+      fieldset.addEventListener('transitionend', removeAnimationBlock);
     });
   }
 

--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -205,8 +205,11 @@ export class DCFFieldsetCollapsible {
       });
       toggleButtonObj.initialize();
 
+      // This lets any outside js that needs to interact with elements inside the fieldset
+      // to know that its safe to create references to these elements
       fieldset.dispatchEvent(this.fieldsetReadyEvent);
 
+      // Remove the classes related to block any animation
       let removeAnimationBlock = () => {
         this.theme.animationBlockClassList.forEach((fieldsetClass) => {
           fieldset.classList.remove(fieldsetClass);
@@ -214,6 +217,7 @@ export class DCFFieldsetCollapsible {
         fieldset.removeEventListener('transitionend', removeAnimationBlock);
       };
 
+      // We want to wait for the css classes to finish changing before removing the classes
       fieldset.addEventListener('transitionend', removeAnimationBlock);
     });
   }

--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -226,7 +226,6 @@ export class DCFFieldsetCollapsible {
   eventListeners(fieldset, toggleElement, button) {
     // We listen for when the toggle element is turned on
     toggleElement.addEventListener(DCFFieldsetCollapsible.events('toggleElementOn'), () => {
-      console.log(fieldset, 'on');
       // When it is we will remove the off styles and add the on styles
       this.theme.fieldsetContentsClassListOff.forEach((toggleElementClass) => {
         toggleElement.classList.remove(toggleElementClass);
@@ -246,7 +245,6 @@ export class DCFFieldsetCollapsible {
 
     // We listen for when the toggle element is turned off
     toggleElement.addEventListener(DCFFieldsetCollapsible.events('toggleElementOff'), () => {
-      console.log(fieldset, 'off');
       // When it is we will remove the on styles and add the off styles
       this.theme.fieldsetContentsClassListOn.forEach((toggleElementClass) => {
         toggleElement.classList.remove(toggleElementClass);

--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -36,7 +36,7 @@ export class DCFFieldsetCollapsibleTheme {
     this.fieldsetClassListOff = [];
 
     this.animationBlockWaitTime = 250;
-    this.animationBlockClassList = [ 'dcf-block-transition', 'dcf-block-animation' ];
+    this.animationBlockClassList = [ 'dcf-motion-none' ];
   }
 
   // Allows us to set the theme variables if they are defined and we match the types

--- a/scss/utilities/_utilities.animation.scss
+++ b/scss/utilities/_utilities.animation.scss
@@ -2,6 +2,15 @@
 // CORE / UTILITIES / ANIMATION
 ///////////////////////////////
 
+.dcf-block-animation {
+  animation-duration: .001ms !important;
+  animation-iteration-count: 1 !important;
+}
+
+.dcf-block-transition {
+  transition-duration: .001ms !important;
+  transition-delay: .001ms !important;
+}
 
 // Fade
 .dcf-js .dcf-fade-in {

--- a/scss/utilities/_utilities.animation.scss
+++ b/scss/utilities/_utilities.animation.scss
@@ -2,12 +2,9 @@
 // CORE / UTILITIES / ANIMATION
 ///////////////////////////////
 
-.dcf-block-animation {
+.dcf-motion-none {
   animation-duration: .001ms !important;
   animation-iteration-count: 1 !important;
-}
-
-.dcf-block-transition {
   transition-duration: .001ms !important;
   transition-delay: .001ms !important;
 }


### PR DESCRIPTION
Added class for blocking any animations or transition. This is to be used for page load when we do not want animations or transitions to run.

Collapsible Field Sets had issues with ones that start collapsed. The transition for them would still run on page load. This would fix that issue