### PR TITLE
Remove nav-menu-child pseudo content

### DIFF
--- a/scss/components/_components.nav-menu.scss
+++ b/scss/components/_components.nav-menu.scss
@@ -70,17 +70,6 @@
   }
 
 
-  .dcf-nav-menu-child::before,
-  .dcf-nav-menu-child::after {
-    content: '';
-    height: #{ms(6)}em;
-    left: 0;
-    position: fixed;
-    width: 100%;
-    z-index: 999;
-  }
-
-
   .dcf-nav-menu a,
   .dcf-nav-menu button {
     margin-left: -#{ms(0)}rem;


### PR DESCRIPTION
The pseudo content was previously used to attach fixed-position gradients to the top and bottom of the nav menu to provide contextual clues to users that the menu contained more content. This no longer works as intended so we are removing it.