### PR TITLE
Hide tabs list item if child tab is hidden

### DIFF
--- a/scss/components/_components.tabs.scss
+++ b/scss/components/_components.tabs.scss
@@ -2,9 +2,11 @@
 // CORE / COMPONENTS / TABS
 ///////////////////////////
 
+
 .dcf-tabs-list-item {
   display: inline-block;
 }
+
 
 .dcf-tabs-scroll:not(.dcf-tabs-responsive) .dcf-tabs-list {
   display: flex;
@@ -14,6 +16,7 @@
   scroll-snap-type: x mandatory;
   overscroll-behavior-x: contain;
 }
+
 
 .dcf-tabs-scroll:not(.dcf-tabs-responsive) .dcf-tabs-list-item {
   scroll-snap-stop: normal;
@@ -40,6 +43,7 @@
   color: $color-tab-selected;
   text-decoration: none;
 }
+
 
 .dcf-tab:not([aria-selected]) {
   background-color: inherit;

--- a/scss/components/_components.tabs.scss
+++ b/scss/components/_components.tabs.scss
@@ -8,6 +8,11 @@
 }
 
 
+.dcf-tabs-list-item:has(.dcf-tab[hidden]) {
+  display: none;
+}
+
+
 .dcf-tabs-scroll:not(.dcf-tabs-responsive) .dcf-tabs-list {
   display: flex;
   flex-flow: row nowrap;


### PR DESCRIPTION
This fixes a subtle display issue where a small space is still present for hidden tabs where there should be none.