### PR TITLE
Misc toggle fixes

### DIFF
--- a/js/dcf-button-toggle.js
+++ b/js/dcf-button-toggle.js
@@ -253,7 +253,7 @@ export class DCFToggleButton {
    * @param {Event} event The event which holds the event target which we will remove the dcf-d-none from
    */
   removeDisplayNone(event) {
-    event.target.classList.add('dcf-d-none');
-    event.target.removeEventListener('transitionend', this.removeDisplayNone);
+    event.currentTarget.classList.add('dcf-d-none');
+    event.currentTarget.removeEventListener('transitionend', this.removeDisplayNone);
   }
 }

--- a/js/dcf-button-toggle.js
+++ b/js/dcf-button-toggle.js
@@ -105,7 +105,7 @@ export class DCFToggleButton {
 
       // ToggleSwitched will set many of the other attributes and styles
       const expandedState = toggleButtonStartExpanded === 'true' ? 'open' : 'close';
-      this.toggleSwitched(toggleButton, toggleElement, expandedState);
+      this.toggleSwitched(toggleButton, toggleElement, expandedState, true);
 
       // set up the event listeners for the button and element
       this.eventListeners(toggleButton, toggleElement);
@@ -178,10 +178,11 @@ export class DCFToggleButton {
 
   // Handles the logic for the button
   // This will only call the animations
-  toggleSwitched(toggleButton, toggleElement, state = '') {
+  toggleSwitched(toggleButton, toggleElement, state = '', onload = false) {
     // Gets the labels for the button
     const toggleButtonLabelOn = toggleButton.dataset.labelOn;
     const toggleButtonLabelOff = toggleButton.dataset.labelOff;
+    const timeoutTime = 10;
 
     // Toggled On
     if ((toggleButton.getAttribute('aria-expanded') === 'false' ||
@@ -195,40 +196,17 @@ export class DCFToggleButton {
       }
       toggleButton.dispatchEvent(this.toggleButtonOn);
 
+      // Removed transitionend if it was there
+      toggleElement.removeEventListener('transitionend', this.removeDisplayNone);
+
+      // Unhide the stuff now so animations can run after
       toggleElement.setAttribute('aria-hidden', 'false');
-      toggleElement.classList.remove('dcf-opacity-0', 'dcf-pointer-events-none');
-      toggleElement.classList.add('dcf-opacity-100', 'dcf-pointer-events-auto');
-
-      // Make everything inside toggle element use old tab index and old disabled value if it had one
-      toggleElement.querySelectorAll('*').forEach((elem) => {
-        if ('oldTabIndex' in elem.dataset && elem.dataset.oldTabIndex !== 'false') {
-          elem.setAttribute('tabindex', elem.dataset.oldTabIndex);
-        } else if ('oldTabIndex' in elem.dataset && elem.dataset.oldTabIndex === 'false') {
-          elem.removeAttribute('tabindex');
-        }
-        delete elem.dataset.oldTabIndex;
-
-        if ('oldDisabled' in elem.dataset && elem.dataset.oldDisabled === 'false') {
-          elem.removeAttribute('disabled');
-        }
-        delete elem.dataset.oldDisabled;
-      });
-
-      // Make toggle element use old tab index if it had one
-      if (toggleElement.dataset.oldTabIndex && toggleElement.dataset.oldTabIndex !== 'false') {
-        toggleElement.setAttribute('tabindex', '-1');
-      } else {
-        toggleElement.removeAttribute('tabindex');
-      }
-      delete toggleElement.dataset.oldTabIndex;
-
-      // Make toggle element use disabled value if it had one
-      if (toggleElement.dataset.oldDisabled && toggleElement.dataset.oldDisabled !== 'false') {
-        toggleElement.disabled = true;
-      } else {
-        toggleElement.removeAttribute('disabled');
-      }
-      delete toggleElement.dataset.oldDisabled;
+      toggleElement.classList.remove('dcf-d-none');
+      // If we do not have this the transition will not run on our toggled elements for some reason
+      setTimeout(() => {
+        toggleElement.classList.remove('dcf-opacity-0', 'dcf-pointer-events-none');
+        toggleElement.classList.add('dcf-opacity-100', 'dcf-pointer-events-auto');
+      }, timeoutTime);
 
       // Dispatch event incase something else is using it
       toggleElement.dispatchEvent(this.toggleElementOn);
@@ -249,23 +227,18 @@ export class DCFToggleButton {
       }
       toggleButton.dispatchEvent(this.toggleButtonOff);
 
+      // Set it to hidden
       toggleElement.setAttribute('aria-hidden', 'true');
       toggleElement.classList.remove('dcf-opacity-100', 'dcf-pointer-events-auto');
       toggleElement.classList.add('dcf-pointer-events-none', 'dcf-opacity-0');
 
-      // Make everything inside toggle element not tabbable and disabled plus saving old values if it had one
-      toggleElement.querySelectorAll('*').forEach((elem) => {
-        elem.dataset.oldTabIndex = elem.getAttribute('tabindex') || 'false';
-        elem.dataset.oldDisabled = elem.disabled;
-        elem.setAttribute('tabindex', '-1');
-        elem.disabled = true;
-      });
-
-      // Make toggle element not tabbable and disabled plus saving old values if it had one
-      toggleElement.dataset.oldTabIndex = toggleElement.getAttribute('tabindex') || 'false';
-      toggleElement.dataset.oldDisabled = toggleElement.disabled;
-      toggleElement.setAttribute('tabindex', '-1');
-      toggleElement.disabled = true;
+      // If it has a transition wait for it to finish before removing display none
+      // If not just remove the class
+      if (onload || window.getComputedStyle(toggleElement, null).getPropertyValue('transition') === '') {
+        toggleElement.classList.add('dcf-d-none');
+      } else {
+        toggleElement.addEventListener('transitionend', this.removeDisplayNone);
+      }
 
       // Dispatch event incase something else is using it
       toggleElement.dispatchEvent(this.toggleElementOff);
@@ -273,5 +246,14 @@ export class DCFToggleButton {
     }
 
     return false;
+  }
+
+  /**
+   * We only have this so we can easily add and remove the transitionend event listeners
+   * @param {Event} event The event which holds the event target which we will remove the dcf-d-none from
+   */
+  removeDisplayNone(event) {
+    event.target.classList.add('dcf-d-none');
+    event.target.removeEventListener('transitionend', this.removeDisplayNone);
   }
 }

--- a/js/dcf-button-toggle.js
+++ b/js/dcf-button-toggle.js
@@ -109,6 +109,10 @@ export class DCFToggleButton {
 
       // set up the event listeners for the button and element
       this.eventListeners(toggleButton, toggleElement);
+
+      if (toggleElement.getAttribute('hidden') !== null) {
+        toggleElement.removeAttribute('hidden');
+      }
     });
   }
 

--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -56,6 +56,7 @@ export class DCFFieldsetCollapsible {
     }
 
     this.fieldsetReadyEvent = new Event(DCFFieldsetCollapsible.events('fieldsetReady'));
+    this.commandToggle = new Event(DCFToggleButton.events('commandToggle'));
 
     // Copy the Keys without copying the references
     // Objects plus their properties and arrays are pass by reference
@@ -130,6 +131,7 @@ export class DCFFieldsetCollapsible {
       // Removed the legend and saves it
       const legendCopy = legend.cloneNode(true);
       legend.remove();
+      legendCopy.style.cursor = 'pointer';
 
       // Creates a new div and we copy everything left in the fieldset into it
       const newGuts = document.createElement('div');
@@ -195,7 +197,7 @@ export class DCFFieldsetCollapsible {
       // We can then add the event listeners
       // We want to do this before the toggle button is initialized
       // Since we have to change the styles for if it starts expanded or not
-      this.eventListeners(fieldset, newGuts, button);
+      this.eventListeners(fieldset, newGuts, button, legendCopy);
 
       // Initialize the toggle button
       const toggleButtonObj = new DCFToggleButton(button, {
@@ -228,8 +230,19 @@ export class DCFFieldsetCollapsible {
    * @param {HTMLElement} fieldset Fieldset that holds the button and toggle element
    * @param {HTMLElement} toggleElement The new div that was made inside the fieldset
    * @param {HTMLElement} button The button that was added to the legend
+   * @param {HTMLElement} legend The legend that holds the button
    */
-  eventListeners(fieldset, toggleElement, button) {
+  eventListeners(fieldset, toggleElement, button, legend) {
+    // If we click the legend and not the button we want to toggle the fieldset
+    legend.addEventListener('click', (event) => {
+      // If the legend does not contain it then we clicked the SVG and the SVG has changed
+      // If e.target is the button we do not want to toggle
+      // If the button contains e.target then we do not want to toggle
+      if (legend.contains(event.target) && !button.isEqualNode(event.target) && !button.contains(event.target)) {
+        button.dispatchEvent(this.commandToggle);
+      }
+    });
+
     // We listen for when the toggle element is turned on
     toggleElement.addEventListener(DCFFieldsetCollapsible.events('toggleElementOn'), () => {
       // When it is we will remove the off styles and add the on styles

--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -27,6 +27,7 @@ export class DCFFieldsetCollapsibleTheme {
     this.fieldsetContentsClassListOff = [
       'dcf-h-0',
       'dcf-overflow-y-hidden',
+      'dcf-overflow-x-hidden',
     ];
 
     this.fieldsetClassList = [];

--- a/js/dcf-collapsible-fieldset.js
+++ b/js/dcf-collapsible-fieldset.js
@@ -212,6 +212,10 @@ export class DCFFieldsetCollapsible {
       // to know that its safe to create references to these elements
       fieldset.dispatchEvent(this.fieldsetReadyEvent);
 
+      if (fieldset.getAttribute('hidden') !== null) {
+        fieldset.removeAttribute('hidden');
+      }
+
       // Remove the classes related to block any animation
       let removeAnimationBlock = () => {
         this.theme.animationBlockClassList.forEach((fieldsetClass) => {

--- a/js/dcf-popup.js
+++ b/js/dcf-popup.js
@@ -156,8 +156,17 @@ export class DCFPopup {
       });
 
       // If any popup on the document opens and it doesn't match we will close
-      document.addEventListener(DCFPopup.events('popupOpen'), (e) => {
-        if (e.target.id !== popup.id) {
+      document.addEventListener(DCFPopup.events('popupOpen'), (event) => {
+        // Check if event is coming from a child popup
+        let eventIsFromTheInside = false;
+        popup.querySelectorAll('.dcf-popup').forEach((innerPopup) => {
+          if (innerPopup.id === event.target.id) {
+            eventIsFromTheInside = true;
+          }
+        });
+
+        // If it is not coming from child and it is not this popup then close the popup
+        if (!eventIsFromTheInside && event.target.id !== popup.id) {
           popupBtn.dispatchEvent(this.commandClose);
         }
       }, true);
@@ -165,10 +174,7 @@ export class DCFPopup {
       // If we click outside the popup close the popup
       // Event listener is on body since we want to check if we click anywhere but element
       document.body.addEventListener('click', (event) => {
-        // We then check if where we clicked has any ancestor element that is out popup
-        const closestPopup = event.target.closest('.dcf-popup');
-        if (closestPopup === null || closestPopup.id !== popup.id) {
-          // If the ids match we can use the secret toggle button to close the popup
+        if (!popup.contains(event.target)) {
           popupBtn.dispatchEvent(this.commandClose);
         }
       }, true);

--- a/js/dcf-popup.js
+++ b/js/dcf-popup.js
@@ -90,18 +90,21 @@ export class DCFPopup {
       }
 
       // Gets the button and validates it
-      const popupBtn = popup.querySelector('.dcf-btn-toggle-popup, .dcf-btn-popup');
+      const popupBtn = popup.querySelector(':scope > .dcf-btn-toggle-popup, :scope > .dcf-btn-popup');
       if (popupBtn === null || popupBtn.tagName !== 'BUTTON') {
         throw new Error('Popup Button Is Missing Or Not A Button Tag');
       }
 
       // Gets the content and validates it
-      const popupContent = popup.querySelector('.dcf-popup-content');
+      const popupContent = popup.querySelector(':scope > .dcf-popup-content');
       if (popupContent === null) {
         throw new Error('Popup Content Is Missing');
       }
 
-      const closeButton = popup.querySelector('.dcf-btn-close-popup, .dcf-btn-popup-close');
+      // We need do do some funky stuff to get the correct close button and not the nested one
+      const closeButton = popup.querySelector(
+        ':scope > .dcf-popup-content > .dcf-btn-close-popup, :scope > .dcf-popup-content > .dcf-btn-popup-close'
+      );
       if (closeButton !== null && closeButton.tagName !== 'BUTTON') {
         throw new Error('Close Button is Not a Button Tag');
       }

--- a/js/dcf-popup.js
+++ b/js/dcf-popup.js
@@ -207,6 +207,10 @@ export class DCFPopup {
           popupBtn.dispatchEvent(this.commandOpen);
         });
       }
+
+      if (popup.getAttribute('hidden') !== null) {
+        popup.removeAttribute('hidden');
+      }
     });
   }
 

--- a/js/dcf-popup.js
+++ b/js/dcf-popup.js
@@ -102,12 +102,18 @@ export class DCFPopup {
       }
 
       // We need do do some funky stuff to get the correct close button and not the nested one
-      const closeButton = popup.querySelector(
-        ':scope > .dcf-popup-content > .dcf-btn-close-popup, :scope > .dcf-popup-content > .dcf-btn-popup-close'
+      const closeButtons = popup.querySelectorAll(
+        ':scope > .dcf-popup-content > .dcf-btn-close-popup' +
+        ', :scope > .dcf-popup-content > .dcf-btn-popup-close' +
+        `, :scope > .dcf-popup-content .dcf-btn-close-popup[data-for="${popup.id}"]` +
+        `, :scope > .dcf-popup-content .dcf-btn-popup-close[data-for="${popup.id}"]`
       );
-      if (closeButton !== null && closeButton.tagName !== 'BUTTON') {
-        throw new Error('Close Button is Not a Button Tag');
-      }
+
+      closeButtons.forEach((closeButton) => {
+        if (closeButton !== null && closeButton.tagName !== 'BUTTON') {
+          throw new Error('Close Button is Not a Button Tag');
+        }
+      });
 
       // Sets the IDs for the btn and content if they aren't already set
       if (popup.id === '') {
@@ -144,11 +150,11 @@ export class DCFPopup {
       toggleButtonObj.initialize();
 
       // if there is a close button and its clicked close the popup
-      if (closeButton !== null) {
+      closeButtons.forEach((closeButton) => {
         closeButton.addEventListener('click', () => {
           popupBtn.dispatchEvent(this.commandClose);
         });
-      }
+      });
 
       // When a popup is toggled open it will dispatch an event
       popupContent.addEventListener(DCFToggleButton.events('toggleElementOn'), () => {

--- a/scss/components/_components.popups.scss
+++ b/scss/components/_components.popups.scss
@@ -15,12 +15,12 @@
 
 .dcf-popup:not([data-alignment="start"]):not([data-alignment="end"]) {
 
-  & .dcf-popup-content {
+  & > .dcf-popup-content {
     transform: translateX(-50%);
   }
 
-  &[data-position="left"] .dcf-popup-content,
-  &[data-position="right"] .dcf-popup-content {
+  &[data-position="left"] > .dcf-popup-content,
+  &[data-position="right"] > .dcf-popup-content {
     transform: translateY(-50%);
   }
 }
@@ -29,7 +29,7 @@
 .dcf-popup[data-point="true"] {
 
   // All points
-  & .dcf-popup-content::before {
+  & > .dcf-popup-content::before {
     background-color: inherit;
     content: "";
     left: calc(50% - #{$size-inline-popup-point} / 2);
@@ -38,21 +38,21 @@
   }
 
   // Top & bottom point height & width
-  &:not([data-position="right"]):not([data-position="left"]) .dcf-popup-content::before {
+  &:not([data-position="right"]):not([data-position="left"]) > .dcf-popup-content::before {
     height: $size-block-popup-point;
     width: $size-inline-popup-point;
   }
 
   // Left & right point height & width
-  &[data-position="left"] .dcf-popup-content::before,
-  &[data-position="right"] .dcf-popup-content::before {
+  &[data-position="left"] > .dcf-popup-content::before,
+  &[data-position="right"] > .dcf-popup-content::before {
     height: $size-inline-popup-point;
     width: $size-block-popup-point;
   }
 
   // Bottom Center
-  &[data-position="bottom"] .dcf-popup-content,
-  &:not([data-position="top"]):not([data-position="right"]):not([data-position="left"]) .dcf-popup-content {
+  &[data-position="bottom"] > .dcf-popup-content,
+  &:not([data-position="top"]):not([data-position="right"]):not([data-position="left"]) > .dcf-popup-content {
     margin-top: $margin-popup-point;
 
     &::before {
@@ -62,7 +62,7 @@
   }
 
   // Top Center
-  &[data-position="top"] .dcf-popup-content {
+  &[data-position="top"] > .dcf-popup-content {
     margin-bottom: $margin-popup-point;
 
     &::before {
@@ -72,7 +72,7 @@
   }
 
   // Left Center
-  &[data-position="left"] .dcf-popup-content {
+  &[data-position="left"] > .dcf-popup-content {
     margin-right: $margin-popup-point;
 
     &::before {
@@ -82,7 +82,7 @@
   }
 
   // Right Center
-  &[data-position="right"] .dcf-popup-content {
+  &[data-position="right"] > .dcf-popup-content {
     margin-left: $margin-popup-point;
 
     &::before {
@@ -93,34 +93,34 @@
 
   // Bottom Start
   // Top Start
-  &[data-alignment="start"]:not([data-position="left"]):not([data-position="right"]) .dcf-popup-content::before {
+  &[data-alignment="start"]:not([data-position="left"]):not([data-position="right"]) > .dcf-popup-content::before {
     left: $size-block-popup-point;
   }
 
   // Bottom End
   // Top End
-  &[data-alignment="end"]:not([data-position="left"]):not([data-position="right"]) .dcf-popup-content::before {
+  &[data-alignment="end"]:not([data-position="left"]):not([data-position="right"]) > .dcf-popup-content::before {
     left: calc(100% - #{$size-block-popup-point} * 2);
   }
 
   // Left Center
   // Right Center
-  &[data-position="left"]:not([data-alignment="start"]):not([data-alignment="end"]) .dcf-popup-content::before,
-  &[data-position="right"]:not([data-alignment="start"]):not([data-alignment="end"]) .dcf-popup-content::before {
+  &[data-position="left"]:not([data-alignment="start"]):not([data-alignment="end"]) > .dcf-popup-content::before,
+  &[data-position="right"]:not([data-alignment="start"]):not([data-alignment="end"]) > .dcf-popup-content::before {
     top: calc(50% - #{$size-inline-popup-point} / 2);
   }
 
   // Left Start
   // Right Start
-  &[data-alignment="start"][data-position="left"] .dcf-popup-content::before,
-  &[data-alignment="start"][data-position="right"] .dcf-popup-content::before {
+  &[data-alignment="start"][data-position="left"] > .dcf-popup-content::before,
+  &[data-alignment="start"][data-position="right"] > .dcf-popup-content::before {
     top: $size-block-popup-point;
   }
 
   // Left End
   // Right End
-  &[data-alignment="end"][data-position="left"] .dcf-popup-content::before,
-  &[data-alignment="end"][data-position="right"] .dcf-popup-content::before {
+  &[data-alignment="end"][data-position="left"] > .dcf-popup-content::before,
+  &[data-alignment="end"][data-position="right"] > .dcf-popup-content::before {
     top: calc(100% - #{$size-block-popup-point} * 2);
   }
 }


### PR DESCRIPTION
This PR fixes many bugs:

- Popups, toggle buttons, and collapsible field set flashing open on load
- Collapsible field set's legend toggles field set
- Collapsible field set horizontal scroll popup up during close
- Nesting toggle button related components

Toggle button related components no longer disable and set tabindex to -1, it now give them `dcf-d-none` class and handles transitions correctly which I had issue with before


Closes #512 
Closes #507
Closes #504