### PR TITLE
Add comments to aid searching for classes with percentages in their name

### DIFF
--- a/scss/utilities/_utilities.opacity.scss
+++ b/scss/utilities/_utilities.opacity.scss
@@ -3,12 +3,13 @@
 /////////////////////////////
 
 
-.dcf-opacity-0 { 
+.dcf-opacity-0 {
   @include opacity-0(!important);
 }
 
 
+// .dcf-opacity-100%
 .dcf-opacity-100, // TODO: deprecate `.dcf-opacity-100`
-.dcf-opacity-100\% { 
+.dcf-opacity-100\% {
   @include opacity-100pc(!important);
 }

--- a/scss/utilities/_utilities.position.scss
+++ b/scss/utilities/_utilities.position.scss
@@ -17,13 +17,8 @@
   @include top-0(!important);
 }
 
-.dcf-top-50\% {
-  @include top-50pc(!important);
-}
-
-.dcf-top-100\% {
-  @include top-100pc(!important);
-}
+.dcf-top-50\% { @include top-50pc(!important); }    // .dcf-top-50%
+.dcf-top-100\% { @include top-100pc(!important); }  // .dcf-top-100%
 
 
 .dcf-pin-right, // Deprecate .dcf-pin-right
@@ -31,13 +26,8 @@
   @include right-0(!important);
 }
 
-.dcf-right-50\% {
-  @include right-50pc(!important);
-}
-
-.dcf-right-100\% {
-  @include right-100pc(!important);
-}
+.dcf-right-50\% { @include right-50pc(!important); }    // .dcf-right-50%
+.dcf-right-100\% { @include right-100pc(!important); }  // .dcf-right-100%
 
 
 .dcf-pin-bottom, // Deprecate .dcf-pin-bottom
@@ -45,13 +35,8 @@
   @include bottom-0(!important);
 }
 
-.dcf-bottom-50\% {
-  @include bottom-50pc(!important);
-}
-
-.dcf-bottom-100\% {
-  @include bottom-100pc(!important);
-}
+.dcf-bottom-50\% { @include bottom-50pc(!important); }    // .dcf-bottom-50%
+.dcf-bottom-100\% { @include bottom-100pc(!important); }  // .dcf-bottom-100%
 
 
 .dcf-pin-left, // Deprecate .dcf-pin-left
@@ -59,10 +44,5 @@
   @include left-0(!important);
 }
 
-.dcf-left-50\% {
-  @include left-50pc(!important);
-}
-
-.dcf-left-100\% {
-  @include left-100pc(!important);
-}
+.dcf-left-50\% { @include left-50pc(!important); }    // .dcf-left-50%
+.dcf-left-100\% { @include left-100pc(!important); }  // .dcf-left-100%


### PR DESCRIPTION
Classes with `%` require the preceding `\` escape character in the CSS. These comments will aid developers who search for the class name used in the markup.