### PR TITLE
Use role=“list” instead of .dcf-list-bare

### DIFF
--- a/scss/components/_components.lists.scss
+++ b/scss/components/_components.lists.scss
@@ -4,6 +4,7 @@
 
 
 // Bare list
+// TODO: deprecate, use [role="list"] instead, see generic/_generic.attributes.scss
 .dcf-list-bare {
   // Fix list-style: none in VoiceOver and Safari: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
   list-style: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg'/%3E");

--- a/scss/generic/_generic.attributes.scss
+++ b/scss/generic/_generic.attributes.scss
@@ -21,3 +21,10 @@
   display: block !important;
   visibility: hidden !important;
 }
+
+
+// Fix list-style: none in VoiceOver and Safari: https://www.scottohara.me/blog/2019/01/12/lists-and-safari.html
+[role="list"] {
+  list-style: none;
+  padding-left: 0;
+}


### PR DESCRIPTION
- Use `role=“list”` to target unstyled lists
- Add comment to `.dcf-list-bare` to eventually deprecate and refer to _generic.attributes.scss file