### PR TITLE
Add styles for button-as-link (`.dcf-btn-as-link`)

### DIFF
--- a/scss/components/_components.buttons.scss
+++ b/scss/components/_components.buttons.scss
@@ -36,6 +36,10 @@
   background-color: transparent;
   border: 0;
   color: $color-link;
+  display: inline;
+  line-height: unset;
+  padding: unset;
+  text-align: unset;
   text-decoration: underline;
 }
 

--- a/scss/components/_components.buttons.scss
+++ b/scss/components/_components.buttons.scss
@@ -3,14 +3,19 @@
 //////////////////////////////
 
 
-.dcf-btn {
+.dcf-btn,
+.dcf-btn-as-link {
   appearance: none;
+  cursor: pointer;
+}
+
+
+.dcf-btn {
   @if ($border-radius-button-roundrect) {
     border-radius: $roundrect;
   }
   border-style: $border-style-button;
   border-width: $border-width-button;
-  cursor: pointer;
   display: inline-block;
   @if (to-number($font-size-button) != to-number(#{ms(0)}em)) {
     font-size: $font-size-button;
@@ -24,6 +29,14 @@
   @if ($text-transform-button-uppercase) {
     text-transform: uppercase;
   }
+}
+
+
+.dcf-btn-as-link {
+  background-color: transparent;
+  border: 0;
+  color: $color-link;
+  text-decoration: underline;
 }
 
 


### PR DESCRIPTION
State-based styles (e.g., `:hover`, `:visited`) to be added in theme.

An example of a use case for this would be a button to open a modal where it would be preferable to style the button like a link but retain the `<button>` element for semantics.