### PR TITLE
Fix wrong include for url-wrap

### DIFF
--- a/scss/utilities/_utilities.typography.scss
+++ b/scss/utilities/_utilities.typography.scss
@@ -32,7 +32,7 @@
 // Text wrap
 .dcf-txt-nowrap { @include txt-nowrap(!important); }
 .dcf-txt-wrap-unset { @include txt-wrap-unset(!important); }
-.dcf-url-wrap { @include word-wrap(!important); }
+.dcf-url-wrap { @include url-wrap(!important); }
 .dcf-word-wrap { @include word-wrap(!important); }
 .dcf-truncate { @include truncate(!important); }
 


### PR DESCRIPTION
Use `url-wrap` include – not `word-wrap` – for the `dcf-url-wrap` utility class.