### PR TITLE
Remove `grid-` prefix from `column-` and `row-gap` classes

### DIFF
--- a/scss/mixins/_mixins.gap.scss
+++ b/scss/mixins/_mixins.gap.scss
@@ -17,27 +17,27 @@
 
 
 // Grid column gap
-@mixin col-gap-1($imp:null) { grid-column-gap: $length-em-1 $imp; }
-@mixin col-gap-2($imp:null) { grid-column-gap: $length-em-2 $imp; }
-@mixin col-gap-3($imp:null) { grid-column-gap: $length-em-3 $imp; }
-@mixin col-gap-4($imp:null) { grid-column-gap: $length-em-4 $imp; }
-@mixin col-gap-5($imp:null) { grid-column-gap: $length-em-5 $imp; }
-@mixin col-gap-6($imp:null) { grid-column-gap: $length-em-6 $imp; }
-@mixin col-gap-7($imp:null) { grid-column-gap: $length-em-7 $imp; }
-@mixin col-gap-8($imp:null) { grid-column-gap: $length-em-8 $imp; }
-@mixin col-gap-9($imp:null) { grid-column-gap: $length-em-9 $imp; }
-@mixin col-gap-10($imp:null) { grid-column-gap: $length-em-10 $imp; }
-@mixin col-gap-vw($imp:null) { grid-column-gap: $length-vw-1 $imp; }
+@mixin col-gap-1($imp:null) { column-gap: $length-em-1 $imp; }
+@mixin col-gap-2($imp:null) { column-gap: $length-em-2 $imp; }
+@mixin col-gap-3($imp:null) { column-gap: $length-em-3 $imp; }
+@mixin col-gap-4($imp:null) { column-gap: $length-em-4 $imp; }
+@mixin col-gap-5($imp:null) { column-gap: $length-em-5 $imp; }
+@mixin col-gap-6($imp:null) { column-gap: $length-em-6 $imp; }
+@mixin col-gap-7($imp:null) { column-gap: $length-em-7 $imp; }
+@mixin col-gap-8($imp:null) { column-gap: $length-em-8 $imp; }
+@mixin col-gap-9($imp:null) { column-gap: $length-em-9 $imp; }
+@mixin col-gap-10($imp:null) { column-gap: $length-em-10 $imp; }
+@mixin col-gap-vw($imp:null) { column-gap: $length-vw-1 $imp; }
 
 
 // Grid row gap
-@mixin row-gap-1($imp:null) { grid-row-gap: $length-em-1 $imp; }
-@mixin row-gap-2($imp:null) { grid-row-gap: $length-em-2 $imp; }
-@mixin row-gap-3($imp:null) { grid-row-gap: $length-em-3 $imp; }
-@mixin row-gap-4($imp:null) { grid-row-gap: $length-em-4 $imp; }
-@mixin row-gap-5($imp:null) { grid-row-gap: $length-em-5 $imp; }
-@mixin row-gap-6($imp:null) { grid-row-gap: $length-em-6 $imp; }
-@mixin row-gap-7($imp:null) { grid-row-gap: $length-em-7 $imp; }
-@mixin row-gap-8($imp:null) { grid-row-gap: $length-em-8 $imp; }
-@mixin row-gap-9($imp:null) { grid-row-gap: $length-em-9 $imp; }
-@mixin row-gap-10($imp:null) { grid-row-gap: $length-em-10 $imp; }
+@mixin row-gap-1($imp:null) { row-gap: $length-em-1 $imp; }
+@mixin row-gap-2($imp:null) { row-gap: $length-em-2 $imp; }
+@mixin row-gap-3($imp:null) { row-gap: $length-em-3 $imp; }
+@mixin row-gap-4($imp:null) { row-gap: $length-em-4 $imp; }
+@mixin row-gap-5($imp:null) { row-gap: $length-em-5 $imp; }
+@mixin row-gap-6($imp:null) { row-gap: $length-em-6 $imp; }
+@mixin row-gap-7($imp:null) { row-gap: $length-em-7 $imp; }
+@mixin row-gap-8($imp:null) { row-gap: $length-em-8 $imp; }
+@mixin row-gap-9($imp:null) { row-gap: $length-em-9 $imp; }
+@mixin row-gap-10($imp:null) { row-gap: $length-em-10 $imp; }


### PR DESCRIPTION
Unprefixed [`column-gap`](https://caniuse.com/mdn-css_properties_column-gap) and [`row-gap`](https://caniuse.com/mdn-css_properties_row-gap) properties are widely supported in modern browsers.