### PR TITLE
Set `width` of `<body>` to `100vw`

### DIFF
--- a/scss/elements/_elements.body.scss
+++ b/scss/elements/_elements.body.scss
@@ -8,4 +8,5 @@ body {
   color: $color-body;
   margin: 0;
   overflow-x: hidden;
+  width: 100vw;
 }


### PR DESCRIPTION
From Matt Bryant: 

> A layout bug in Windows Chrome and Edge shifts elements wrapped in the `dcf-bleed` class to the right. The cause is that Chromium changed how the scrollbars are calculated in the viewport width earlier this year—they are not `overlay` by default.
> Fortunately, the fix is dead simple as outlined here: https://ux.stackexchange.com/questions/145259/should-scrollbars-be-integrated-into-the-viewport-width-when-content-differs
> We just need to add `width: 100vw` to the `<body>` tag since you already have `overflow-x: hidden;` applied to the `<body>`.