### PR TITLE
Set button `font-weight` for more granular control

### DIFF
--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -24,9 +24,7 @@
   @if (func.to-number(var.$font-size-button) != func.to-number(#{var.$ms00}em)) {
     font-size: var.$font-size-button;
   }
-  @if (var.$font-weight-button-bold) {
-    font-weight: bold;
-  }
+  font-weight: var.$font-weight-button;
   line-height: var.$line-height-button;
   @if (func.to-number(var.$margin-bottom-button) != func.to-number(0)) {
     margin-bottom: var.$margin-bottom-button;

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -196,9 +196,7 @@
   @if (func.to-number(var.$font-size-button) != func.to-number(#{var.$ms00}em)) {
     font-size: var.$font-size-button;
   }
-  @if (var.$font-weight-button-bold) {
-    font-weight: bold;
-  }
+  font-weight: var.$font-weight-button;
   line-height: var.$line-height-button;
   padding: var.$padding-top-button var.$padding-right-button var.$padding-bottom-button var.$padding-left-button;
   text-align: center;

--- a/scss/variables/_buttons.scss
+++ b/scss/variables/_buttons.scss
@@ -105,7 +105,7 @@ $font-size-button: #{ms.$ms-1}em !default;          // Button font-size: .84em
 
 
 // Font weight
-$font-weight-button: bold;                          // Button font-weight
+$font-weight-button: bold !default;                 // Button font-weight
 
 
 // Line height

--- a/scss/variables/_buttons.scss
+++ b/scss/variables/_buttons.scss
@@ -105,7 +105,7 @@ $font-size-button: #{ms.$ms-1}em !default;          // Button font-size: .84em
 
 
 // Font weight
-$font-weight-button-bold: true !default;            // Bold button text? True/false
+$font-weight-button: bold;                          // Button font-weight
 
 
 // Line height


### PR DESCRIPTION
Instead of a boolean for `bold` only, allow button `font-weight` to be set as needed (heavy, semibold, light, etc.).