### PR TITLE
Temporarily restore `<body>` `overflow-x: hidden` and `width: 100vw`

### DIFF
--- a/scss/elements/_body.scss
+++ b/scss/elements/_body.scss
@@ -9,4 +9,6 @@
 body {
   background-color: var.$bg-color-body;
   color: var.$color-body;
+  overflow-x: hidden;
+  width: 100vw;
 }


### PR DESCRIPTION
These will be removed after updating `<body>` layout to `grid`/`subgrid` in 6.1.