### PR TITLE
Fix Input Group Z-index

### DIFF
--- a/scss/components/_input-groups.scss
+++ b/scss/components/_input-groups.scss
@@ -18,7 +18,11 @@
 //  Child input field of input group
 .dcf-input-group input:not(.dcf-btn) {
   flex: 1 1 auto; // Grow/shrink as needed, with auto width
-  z-index: 1; // Place :focus and :hover states (e.g., borders, outlines) above input group add-ons
+}
+
+.dcf-input-group :focus,
+.dcf-input-group :focus-visible {
+  z-index: 1; // Place :focus and :hover states (e.g., borders, outlines) above input group siblings
 }
 
 

--- a/scss/components/_input-groups.scss
+++ b/scss/components/_input-groups.scss
@@ -20,6 +20,7 @@
   flex: 1 1 auto; // Grow/shrink as needed, with auto width
 }
 
+
 .dcf-input-group :focus,
 .dcf-input-group :focus-visible {
   z-index: 1; // Place :focus and :hover states (e.g., borders, outlines) above input group siblings


### PR DESCRIPTION
`z-index: 1;` was only applied to input element which lead to situations where the button was behind another item on the page. This only applied the `z-index: 1;` when you are focused on the element which will preserve the border/outline being on top of the other elements.