### PR TITLE
Update Tabs Styling

### DIFF
--- a/js/components/dcf-tab.js
+++ b/js/components/dcf-tab.js
@@ -76,7 +76,7 @@ export default class DCFTabs {
         }
 
         // Adds classes to the tabList and sets role
-        this.tabsList.classList.add('dcf-tabs-list', 'dcf-list-bare', 'dcf-mb-0');
+        this.tabsList.classList.add('dcf-tabs-list', 'dcf-mb-0', 'dcf-pl-0');
         this.tabsList.setAttribute('role', 'tablist');
 
         // Add tab panel semantics and hide them all in each tab group.

--- a/scss/components-js/_tabs.scss
+++ b/scss/components-js/_tabs.scss
@@ -79,4 +79,8 @@
     display: block;
   }
 
+  .dcf-tabs-responsive .dcf-tab {
+    width: 100%;
+  }
+
 }


### PR DESCRIPTION
- Remove `dcf-list-bare` class (no longer used) and use padding utility (`dcf-pl-0`) instead.
- Set responsive tab width to 100% for mobile