### PR TITLE
Remove `dcf-d-block` class from framework images

### DIFF
--- a/js/components/dcf-gallery.js
+++ b/js/components/dcf-gallery.js
@@ -77,7 +77,7 @@ export class DCFGalleryDialog {
     <div class="dcf-gallery-prev dcf-d-flex dcf-ai-center">
         <button class="dcf-btn dcf-btn-secondary dcf-gallery-btn-prev dcf-d-flex dcf-jc-center dcf-ai-center dcf-h-7 dcf-w-7 dcf-circle" style="padding: 0px;">
             <span class="dcf-sr-only">Previous Image</span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="dcf-fill-current dcf-h-4 dcf-w-4 dcf-d-block" style="rotate: 180deg;" viewBox="0 0 30 36">
+            <svg xmlns="http://www.w3.org/2000/svg" class="dcf-fill-current dcf-h-4 dcf-w-4" style="rotate: 180deg;" viewBox="0 0 30 36">
             <path d="M25.5,15.3L9.3,0.9C8.6,0.3,7.6,0,6.7,0c-1,0.1-1.9,0.5-2.5,1.2
             C3.5,2,3.2,2.9,3.3,3.8c0.1,1,0.5,1.9,1.2,2.5L17.7,18
             L4.5,29.7c-0.7,0.6-1.2,1.5-1.2,2.5c-0.1,1,0.3,1.9,0.9,2.6
@@ -89,7 +89,7 @@ export class DCFGalleryDialog {
     <div class="dcf-gallery-next dcf-d-flex dcf-ai-center">
         <button class="dcf-btn dcf-btn-secondary dcf-gallery-btn-next dcf-d-flex dcf-jc-center dcf-ai-center dcf-h-7 dcf-w-7 dcf-circle" style="padding: 0px;">
             <span class="dcf-sr-only">Next Image</span>
-            <svg xmlns="http://www.w3.org/2000/svg" class="dcf-fill-current dcf-h-4 dcf-w-4 dcf-d-block" viewBox="0 0 30 36">
+            <svg xmlns="http://www.w3.org/2000/svg" class="dcf-fill-current dcf-h-4 dcf-w-4" viewBox="0 0 30 36">
                 <path d="M25.5,15.3L9.3,0.9C8.6,0.3,7.6,0,6.7,0c-1,0.1-1.9,0.5-2.5,1.2
                 C3.5,2,3.2,2.9,3.3,3.8c0.1,1,0.5,1.9,1.2,2.5L17.7,18
                 L4.5,29.7c-0.7,0.6-1.2,1.5-1.2,2.5c-0.1,1,0.3,1.9,0.9,2.6
@@ -210,7 +210,6 @@ export class DCFGalleryDialog {
         newLi.setAttribute('tabindex', selected ? '0' : '-1');
         newLi.innerHTML = `<div class="dcf-1x1 dcf-w-9 dcf-rounded">
     <img
-        class="dcf-d-block"
         ${imageElement.getAttribute('src') !== null ? `src='${imageElement.getAttribute('src')}'` : ''}
         ${imageElement.getAttribute('srcset') !== null ? `srcset='${imageElement.getAttribute('srcset')}'` : ''}
         ${imageElement.getAttribute('crossorigin') !== null ? `crossorigin='${imageElement.getAttribute('crossorigin')}'` : ''}

--- a/js/components/dcf-search-select.js
+++ b/js/components/dcf-search-select.js
@@ -99,7 +99,7 @@ export default class DCFSearchSelect {
     ];
 
     selectedItemButtonSVG = `<svg
-    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" class="dcf-fill-current dcf-w-4 dcf-h-4 dcf-d-block">
+    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" class="dcf-fill-current dcf-w-4 dcf-h-4">
     <path d="M25.4,22.6L15.8,13l9.6-9.6C25.8,3,26,2.5,26,2s-0.2-1-0.6-1.4c-0.8-0.8-2.1-0.8-2.8,0L13,10.2L3.4,0.6
         c-0.8-0.8-2-0.8-2.8,0c-0.8,0.8-0.8,2,0,2.8l9.6,9.6l-9.6,9.6C0.2,23,0,23.5,0,24c0,0.5,0.2,1,0.6,1.4C1,25.8,1.5,26,2,26
         c0.5,0,1-0.2,1.4-0.6l9.6-9.6l9.6,9.6C23,25.8,23.5,26,24,26c0,0,0,0,0,0c0.5,0,1-0.2,1.4-0.6C25.8,25,26,24.5,26,24
@@ -127,7 +127,7 @@ export default class DCFSearchSelect {
     toggleButtonSVG = `<svg
 xmlns="http://www.w3.org/2000/svg"
 viewBox="0 0 24 24"
-class="dcf-fill-current dcf-w-3 dcf-h-3 dcf-d-block"
+class="dcf-fill-current dcf-w-3 dcf-h-3"
 aria-hidden="true"
 >
 <path d="M23.936,2.255C23.848,2.098,23.681,2,23.5,2h-23
@@ -181,7 +181,7 @@ aria-hidden="true"
     ];
 
     availableItemIndicatorSVG = `<svg
-    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" class="dcf-fill-current dcf-h-4 dcf-w-4 dcf-d-block">
+    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" class="dcf-fill-current dcf-h-4 dcf-w-4">
     <path d="M31,0.4C30.6,0.1,30-0.1,29.4,0c-0.6,0.1-1.1,0.4-1.5,0.9
     L10.1,26.3L3.8,20c-0.4-0.4-1-0.6-1.6-0.6c0,0,0,0,0,0
     c-0.6,0-1.2,0.2-1.6,0.6C0.2,20.5,0,21,0,21.6

--- a/js/components/dcf-slideshow.js
+++ b/js/components/dcf-slideshow.js
@@ -331,11 +331,6 @@ width="24" height="24" viewBox="0 0 24 24" focusable="false" aria-hidden="true">
             figure.classList.add('dcf-slide-figure');
         });
 
-        // Images default to display inline which causes a weird gap below image
-        // This class will remove that gap
-        this.slideshowContainer.querySelectorAll('img').forEach((image) => {
-            image.classList.add('dcf-d-block');
-        });
     }
 
     /**


### PR DESCRIPTION
Images are already set to `display: block` by default in 4.0.