### PR TITLE
Replace `font-weight` `bold` name value with variables and mixins

### DIFF
--- a/scss/components-js/_tabs.scss
+++ b/scss/components-js/_tabs.scss
@@ -4,8 +4,8 @@
 
 
 @use "../variables/" as var;
-@use "../functions/" as func;
 @use "../mixins/" as mixins;
+@use "../functions/" as func;
 
 
 .dcf-tabs-list-item {
@@ -42,7 +42,7 @@
   }
   // If the $font-weight-tab-bold variable = true, then change the font-weight to bold
   @if (var.$font-weight-tab-bold) {
-    font-weight: bold;
+    @include mixins.bold;
   }
   padding: var.$padding-top-tab var.$padding-right-tab var.$padding-bottom-tab var.$padding-left-tab;
 }

--- a/scss/components/_forms.scss
+++ b/scss/components/_forms.scss
@@ -31,7 +31,7 @@
     font-size: var.$font-size-legend;
   }
   @if (var.$font-weight-legend-bold) {
-    font-weight: bold;
+    @include mixins.bold;
   }
   margin-left: -#{var.$padding-legend}; // Left align legend with form elements
   padding-left: var.$padding-legend;

--- a/scss/components/_tables.scss
+++ b/scss/components/_tables.scss
@@ -4,8 +4,8 @@
 
 
 @use "../variables/" as var;
-@use "../functions/" as func;
 @use "../mixins/" as mixins;
+@use "../functions/" as func;
 
 
 .dcf-table caption {
@@ -16,7 +16,7 @@
   }
   // If the var.$font-weight-caption-bold variable = true, then change the font-weight to bold
   @if (var.$font-weight-caption-bold) {
-    font-weight: bold;
+    @include mixins.bold;
   }
   padding-bottom: var.$padding-bottom-caption;
   @if (var.$text-wrap-balance-caption == true) {
@@ -169,7 +169,7 @@
   .dcf-table-responsive tbody td[data-label]::before {
     content: attr(data-label);
     display: table-cell;
-    font-weight: bold;
+    @include mixins.bold;
     padding-right: var.$padding-right-table-cell;
     width: var.$width-table-responsive-data-label;
   }

--- a/scss/elements/_details-summary.scss
+++ b/scss/elements/_details-summary.scss
@@ -4,6 +4,7 @@
 
 
 @use "../variables/" as var;
+@use "../mixins/" as mixins;
 @use "../functions/" as func;
 
 
@@ -37,7 +38,7 @@ summary {
     font-size: var.$font-size-summary;
   }
   @if (var.$font-weight-summary-bold) {
-    font-weight: bold;
+    @include mixins.bold;
   }
 }
 

--- a/scss/elements/_lists.scss
+++ b/scss/elements/_lists.scss
@@ -4,6 +4,7 @@
 
 
 @use "../variables/" as var;
+@use "../mixins/" as mixins;
 
 
 // Avoid markers altering the line-height in Firefox.
@@ -63,7 +64,7 @@ li {
 @if (var.$font-weight-dt-bold) {
 
   dt {
-    font-weight: bold;
+    @include mixins.bold;
   }
 
 }

--- a/scss/elements/_typography.scss
+++ b/scss/elements/_typography.scss
@@ -4,9 +4,10 @@
 
 
 @use "../variables/" as var;
+@use "../mixins/" as mixins;
 
 
 // Bold, strong
 b, strong {
-  font-weight: var.$font-weight-bold;
+  @include mixins.bold;
 }

--- a/scss/variables/_buttons.scss
+++ b/scss/variables/_buttons.scss
@@ -8,6 +8,7 @@
 @use './color-palette' as color_palette;
 @use './modular-scale' as ms;
 @use './sizing' as s;
+@use './typography' as txt;
 
 
 // Background color (inverse listed first for use with non-inverse in dark mode)
@@ -101,34 +102,34 @@ $color-button-secondary-tertiary-hover: var(--btn-secondary-tertiary-hover) !def
 
 
 // Font size
-$font-size-button: #{ms.$ms-1}em !default;          // Button font-size: .84em
+$font-size-button: #{ms.$ms-1}em !default;              // Button font-size: .84em
 
 
 // Font weight
-$font-weight-button: bold !default;                 // Button font-weight
+$font-weight-button: txt.$font-weight-bold !default;    // Button font-weight
 
 
 // Line height
-$line-height-button: #{ms.$ms03} !default;          // Button line-height
+$line-height-button: #{ms.$ms03} !default;              // Button line-height
 
 
 // Margin
-$margin-bottom-button: 0 !default;                  // Margin-bottom of button: 0
-$margin-left-button: 0 !default;                    // Margin-left of button: 0
-$margin-right-button: 0 !default;                   // Margin-right of button: 0
-$margin-top-button: 0 !default;                     // Margin-top of button: 0
+$margin-bottom-button: 0 !default;                      // Margin-bottom of button: 0
+$margin-left-button: 0 !default;                        // Margin-left of button: 0
+$margin-right-button: 0 !default;                       // Margin-right of button: 0
+$margin-top-button: 0 !default;                         // Margin-top of button: 0
 
 
 // Padding
-$padding-bottom-button: s.$length-em-3 !default;    // Padding-bottom of button: .75em
-$padding-left-button: s.$length-em-4 !default;      // Padding-left of button: 1em
-$padding-right-button: s.$length-em-4 !default;     // Padding-right of button: 1em
-$padding-top-button: s.$length-em-3 !default;       // Padding-top of button: .75em
+$padding-bottom-button: s.$length-em-3 !default;        // Padding-bottom of button: .75em
+$padding-left-button: s.$length-em-4 !default;          // Padding-left of button: 1em
+$padding-right-button: s.$length-em-4 !default;         // Padding-right of button: 1em
+$padding-top-button: s.$length-em-3 !default;           // Padding-top of button: .75em
 
 
 // Text alignment
-$text-align-button-center: true !default;           // Center align button text? True/false
+$text-align-button-center: true !default;               // Center align button text? True/false
 
 
 // Text transform
-$text-transform-button-uppercase: false !default;   // Uppercase button text? True/false
+$text-transform-button-uppercase: false !default;       // Uppercase button text? True/false

--- a/scss/variables/_paragraphs.scss
+++ b/scss/variables/_paragraphs.scss
@@ -4,32 +4,33 @@
 
 
 @use './modular-scale' as ms;
+@use './typography' as txt;
 
 
 // Font size
-$font-size-drop-cap: #{ms.$ms11}em !default;        // Drop cap font-size: 4.74em
+$font-size-drop-cap: #{ms.$ms11}em !default;              // Drop cap font-size: 4.74em
 
 
 // Font weight
-$font-weight-drop-cap: bold !default;               // Drop cap font-weight
+$font-weight-drop-cap: txt.$font-weight-bold !default;    // Drop cap font-weight
 
 
 // Line height
 // Adjust line-height for Chrome & Safari after first adjusting margin-top for Firefox
-$line-height-drop-cap: #{ms.$ms-3} !default;        // Drop cap line-height: .63
+$line-height-drop-cap: #{ms.$ms-3} !default;              // Drop cap line-height: .63
 
 
 // Margin
-$margin-bottom-paragraph: #{ms.$ms00}rem !default;  // Paragraph margin-bottom: 1rem
-$margin-top-paragraph: 0 !default;               // Paragraph margin-top: 0
+$margin-bottom-paragraph: #{ms.$ms00}rem !default;        // Paragraph margin-bottom: 1rem
+$margin-top-paragraph: 0 !default;                        // Paragraph margin-top: 0
 // Adjust margin-top for Firefox, then adjust line-height
-$margin-top-drop-cap: #{ms.$ms-1}rem !default;      // Drop cap margin-top: .84rem
+$margin-top-drop-cap: #{ms.$ms-1}rem !default;            // Drop cap margin-top: .84rem
 
 
 // Padding
-$padding-left-drop-cap: #{ms.$ms-20}rem !default;   // Padding-left for drop cap: .06rem
-$padding-right-drop-cap: #{ms.$ms-4}rem !default;   // Padding-right for drop cap: .56rem
+$padding-left-drop-cap: #{ms.$ms-20}rem !default;         // Padding-left for drop cap: .06rem
+$padding-right-drop-cap: #{ms.$ms-4}rem !default;         // Padding-right for drop cap: .56rem
 
 
 // Text wrap
-$text-wrap-pretty-paragraph: true !default;      // Prevent orphans in paragraphs? True/false
+$text-wrap-pretty-paragraph: true !default;               // Prevent orphans in paragraphs? True/false


### PR DESCRIPTION
Use variable and mixin for more granular, numeric `font-weight` control.