### PR TITLE
Fix closed dialog display

### DIFF
--- a/scss/components-js/_dialogs.scss
+++ b/scss/components-js/_dialogs.scss
@@ -20,6 +20,13 @@ html:has(dialog.dcf-dialog-is-open) {
 }
 
 
+// Make sure to hide dialogs if they are closed
+.dcf-dialog:not(.dcf-dialog-is-open),
+.dcf-dialog:not([open]) {
+  display: none !important;
+}
+
+
 // Dialog
 .dcf-dialog {
   background-color: var.$bg-color-dialog;


### PR DESCRIPTION
If `dcf-dialog` has a display utility class then they might not close correctly. This will force the dialog not display when closed