### PR TITLE
Restore `relative` positioning to `#dcf-main`

### DIFF
--- a/scss/elements/_main.scss
+++ b/scss/elements/_main.scss
@@ -1,0 +1,10 @@
+/////////////////////////
+// CORE / ELEMENTS / MAIN
+/////////////////////////
+
+
+// Apply relative positioning to main element for proper
+// placement of Notice component in main content region
+main {
+  position: relative;
+}

--- a/scss/objects/_index.scss
+++ b/scss/objects/_index.scss
@@ -1,3 +1,4 @@
 @forward "./bleed";
 @forward "./grids";
+@forward "./main";
 @forward "./wrapper";

--- a/scss/objects/_main.scss
+++ b/scss/objects/_main.scss
@@ -1,10 +1,10 @@
-/////////////////////////
-// CORE / ELEMENTS / MAIN
-/////////////////////////
+////////////////////////
+// CORE / OBJECTS / MAIN
+////////////////////////
 
 
 // Apply relative positioning to main element for proper
 // placement of Notice component in main content region
-main {
+#dcf-main {
   position: relative;
 }


### PR DESCRIPTION
[Restore](https://github.com/digitalcampusframework/dcf/blob/3.0/scss/objects/_objects.main.scss) `relative` positioning to `#dcf-main` for proper placement of [Notice component](https://github.com/digitalcampusframework/dcf/blob/4.0/js/components/dcf-notice.js#L59) in main content region. 