### PR TITLE
Use `dvh` for dialogs

### DIFF
--- a/scss/variables/_dialogs.scss
+++ b/scss/variables/_dialogs.scss
@@ -18,5 +18,5 @@ $color-dialog: var(--body) !default;                                    // Dialo
 
 
 // Height & width
-$max-height-dialog: calc(100vh - (2 * #{s.$length-em-4})) !default;     // Max-height dialog
+$max-height-dialog: calc(100dvh - (2 * #{s.$length-em-4})) !default;    // Max-height dialog
 $width-dialog: calc(100% - (2 * #{s.$length-vw-2})) !default;           // Match width of .dcf-wrapper


### PR DESCRIPTION
[100dvh](https://www.bram.us/2021/07/08/the-large-small-and-dynamic-viewports/#dynamic-viewport) fixes the [“100vh in Safari on iOS” issue](https://www.bram.us/2020/05/06/100vh-in-safari-on-ios/).