### PR TITLE
Add options for collapsible field set in image cropper 

### DIFF
--- a/js/components/dcf-image-cropper.js
+++ b/js/components/dcf-image-cropper.js
@@ -133,9 +133,9 @@ export default class DCFImageCropper {
 
         // Initialize the fieldset
         if (options.collapsibleFieldset === undefined) {
-            new DCFCollapsibleFieldsets(this.guideFieldsetElement);
+            new DCFCollapsibleFieldsets(this.guideFieldsetElement, options);
         } else {
-            new options.collapsibleFieldset(this.guideFieldsetElement);
+            new options.collapsibleFieldset(this.guideFieldsetElement, options);
         }
 
         // Initialize the state of the component


### PR DESCRIPTION
There was no way to pass in options to the collapsible field set in the image cropper. This causes an issue where the collapsible field set will have an incorrect configuration in regards to the themes which it is being used.

Change: 

- Pass options from the image cropper to the collapsible field set