### PR TITLE
Focus reveals text decor as well

### DIFF
--- a/scss/utilities/_typography.scss
+++ b/scss/utilities/_typography.scss
@@ -47,6 +47,7 @@
 .dcf-txt-decor-none { @include mixins.txt-decor-none; }
 .dcf-txt-decor-hover { @include mixins.txt-decor-hover-off; }
 .dcf-txt-decor-hover:hover { @include mixins.txt-decor-hover-on; }
+.dcf-txt-decor-hover:focus { @include mixins.txt-decor-hover-on; }
 
 
 // Text wrap


### PR DESCRIPTION
For accessibility concerns we made sure `.dcf-txt-decor-hover` also reveals the text decoration on `:focus` as well as `:hover`

Reference: [https://www.w3.org/WAI/WCAG22/Techniques/general/G183](https://www.w3.org/WAI/WCAG22/Techniques/general/G183)