### PR TITLE
Reduce popup arrow/point overlap with popup

### DIFF
--- a/scss/components-js/_popups.scss
+++ b/scss/components-js/_popups.scss
@@ -60,7 +60,7 @@
 
     &::before {
       clip-path: polygon(50% 0, 0 100%, 100% 100%);
-      top: calc(calc(-1 * #{var.$size-block-popup-point}) + .5px);
+      top: calc(calc(-1 * #{var.$size-block-popup-point}) + .25px);
     }
   }
 
@@ -70,7 +70,7 @@
 
     &::before {
       clip-path: polygon(100% 0, 0 0, 50% 100%);
-      top: calc(100% - .5px);
+      top: calc(100% - .25px);
     }
   }
 
@@ -80,7 +80,7 @@
 
     &::before {
       clip-path: polygon(0 0, 0 100%, 100% 50%);
-      left: calc(100% - .5px);
+      left: calc(100% - .25px);
     }
   }
 
@@ -90,7 +90,7 @@
 
     &::before {
       clip-path: polygon(100% 100%, 100% 0, 0 50%);
-      left: calc(calc(-1 * #{var.$size-block-popup-point}) + .5px);
+      left: calc(calc(-1 * #{var.$size-block-popup-point}) + .25px);
     }
   }
 


### PR DESCRIPTION
Retain overlap to avoid unwanted gaps rendered by the browser at some viewport lengths.

Reduce overlap so the arrow/point and popup backgrounds don’t compound if the background color is semi-transparent. (This isn't always entirely foolproof but works most of the time.)