### PR TITLE
Remove browser default borders from `iframe`s

### DIFF
--- a/scss/elements/_media.scss
+++ b/scss/elements/_media.scss
@@ -8,3 +8,9 @@ audio, canvas, embed, iframe, img, object, picture, svg, video {
   height: auto;
   max-width: 100%;
 }
+
+
+// Remove browser default borders from iframes
+iframe {
+  border: 0;
+}


### PR DESCRIPTION
Borders can be added as needed in the theme.