### PR TITLE
Add grid columns to slideshow deck

### DIFF
--- a/js/components/dcf-slideshow.js
+++ b/js/components/dcf-slideshow.js
@@ -40,6 +40,7 @@ export default class DCFSlideshow {
 
     slideDeckClassList = [
         'dcf-d-grid',
+        'dcf-grid-cols-1',
         'dcf-ai-center',
         'dcf-jc-center',
         'dcf-mb-0',


### PR DESCRIPTION
Slide contents won’t always fill the full slide deck area unless the grid columns are defined.