### PR TITLE
Update dcf-bleed

### DIFF
--- a/scss/elements/_body.scss
+++ b/scss/elements/_body.scss
@@ -9,6 +9,5 @@
 body {
   background-color: var.$bg-color-body;
   color: var.$color-body;
-  overflow-x: hidden;
-  width: 100vw;
+  container-type: inline-size;
 }

--- a/scss/objects/_bleed.scss
+++ b/scss/objects/_bleed.scss
@@ -4,10 +4,7 @@
 
 
 .dcf-bleed {
-  /* Expand the width to exactly match the body container */
   width: 100cqw;
-
-  /* Pull the element out from its container mathematically */
   margin-inline-start: calc(50% - 50cqw);
   margin-inline-end: calc(50% - 50cqw);
 }

--- a/scss/objects/_bleed.scss
+++ b/scss/objects/_bleed.scss
@@ -4,10 +4,10 @@
 
 
 .dcf-bleed {
-  left: 50%;
-  margin-left: -50vw;
-  margin-right: -50vw;
-  position: relative;
-  right: 50%;
-  width: 100vw;
+  /* Expand the width to exactly match the body container */
+  width: 100cqw;
+
+  /* Pull the element out from its container mathematically */
+  margin-inline-start: calc(50% - 50cqw);
+  margin-inline-end: calc(50% - 50cqw);
 }


### PR DESCRIPTION
Changes:

- Remove `width: 100vw;` and `overflow-x: hidden;` from body
- Added container type to body
- Updated `.dcf-bleed` to reference body container width (`cqw`) instead of `vw`