### PR TITLE
Update dcf-card-as-link.js

### DIFF
--- a/js/components/dcf-card-as-link.js
+++ b/js/components/dcf-card-as-link.js
@@ -17,10 +17,7 @@ export default class DCFCardAsLink {
     constructor(card) {
         this.card = card;
 
-        this.link = card.querySelector('.dcf-card-link');
-        if (!this.link) {
-            this.link = card.querySelector('a');
-        }
+        this.link = card.querySelector('.dcf-card-link') || card.querySelector('a);
 
         // Add event listeners only if a link is present in the card
         if (this.link) {

--- a/js/components/dcf-card-as-link.js
+++ b/js/components/dcf-card-as-link.js
@@ -1,10 +1,6 @@
-import { uuidv4 } from '../dcf-utility.js';
-
 // Based on https://inclusive-components.design/cards/
 // Using mousedown and mouseup to allow selecting text without trigger click
 export default class DCFCardAsLink {
-    uuid = uuidv4();
-
     card = null;
 
     link = null;
@@ -20,13 +16,10 @@ export default class DCFCardAsLink {
     // Set up the Card as Link component
     constructor(card) {
         this.card = card;
-        if (this.card.getAttribute('id') === '' || this.card.getAttribute('id') === null) {
-            this.card.setAttribute('id', this.uuid.concat('-card-as-link'));
-        }
 
         this.link = card.querySelector('.dcf-card-link');
-        if (this.link.getAttribute('id') === '' || this.link.getAttribute('id') === null) {
-            this.link.setAttribute('id', this.uuid.concat('-card-as-link-link'));
+        if (!this.link) {
+            this.link = card.querySelector('a');
         }
 
         // Add event listeners only if a link is present in the card

--- a/js/components/dcf-card-as-link.js
+++ b/js/components/dcf-card-as-link.js
@@ -17,7 +17,7 @@ export default class DCFCardAsLink {
     constructor(card) {
         this.card = card;
 
-        this.link = card.querySelector('.dcf-card-link') || card.querySelector('a);
+        this.link = card.querySelector('.dcf-card-link') || card.querySelector('a');
 
         // Add event listeners only if a link is present in the card
         if (this.link) {


### PR DESCRIPTION
removed id code, there were no methods in here that used/required ids be present on the card or link elements. there is no reason to require it.

a clickable container with nested links is semantically confusing, should be only one link. included branch such that the decorator `.dcf-card-link` is not necessary ( but still supported if its present )